### PR TITLE
Fix Pi package publish and expand the pi-hypa npm README

### DIFF
--- a/.github/workflows/pi-package-release.yml
+++ b/.github/workflows/pi-package-release.yml
@@ -31,12 +31,17 @@ jobs:
       - name: Resolve version
         id: version
         shell: pwsh
+        env:
+          # Pass event data through env vars rather than ${{ }} interpolation into the
+          # script body, so untrusted values can't be injected into the run step.
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          RUN_TAG: ${{ github.event.workflow_run.head_branch }}
         run: |
           # workflow_dispatch carries the tag in inputs; workflow_run runs in the
           # default-branch context, so GITHUB_REF_NAME is 'main' — read the upstream
           # Release run's head_branch (the pushed tag) instead.
-          $tag = "${{ github.event.inputs.tag }}"
-          if ([string]::IsNullOrWhiteSpace($tag)) { $tag = "${{ github.event.workflow_run.head_branch }}" }
+          $tag = $env:INPUT_TAG
+          if ([string]::IsNullOrWhiteSpace($tag)) { $tag = $env:RUN_TAG }
           if ([string]::IsNullOrWhiteSpace($tag)) { $tag = $env:GITHUB_REF_NAME }
           if ($tag -notmatch '^v\d+\.\d+\.\d+$') { throw "Tag must be vX.Y.Z. Got '$tag'." }
           $version = $tag.Substring(1)

--- a/.github/workflows/pi-package-release.yml
+++ b/.github/workflows/pi-package-release.yml
@@ -32,7 +32,11 @@ jobs:
         id: version
         shell: pwsh
         run: |
+          # workflow_dispatch carries the tag in inputs; workflow_run runs in the
+          # default-branch context, so GITHUB_REF_NAME is 'main' — read the upstream
+          # Release run's head_branch (the pushed tag) instead.
           $tag = "${{ github.event.inputs.tag }}"
+          if ([string]::IsNullOrWhiteSpace($tag)) { $tag = "${{ github.event.workflow_run.head_branch }}" }
           if ([string]::IsNullOrWhiteSpace($tag)) { $tag = $env:GITHUB_REF_NAME }
           if ($tag -notmatch '^v\d+\.\d+\.\d+$') { throw "Tag must be vX.Y.Z. Got '$tag'." }
           $version = $tag.Substring(1)

--- a/packages/pi-hypa/README.md
+++ b/packages/pi-hypa/README.md
@@ -1,25 +1,52 @@
 # pi-hypa
 
-Pi extension package for Hypa. Installing this package through Pi also installs `@hypabolic/hypa` as a package dependency and creates a best-effort user-level `hypa` shim when no `hypa` command is already on `PATH`. The shim delegates to a later global/system `hypa` install if one appears earlier on `PATH`, and otherwise falls back to the bundled dependency.
+**The Pi extension for Hypa — a local context runtime for coding agents.**
 
-The current package provides:
+[![npm](https://img.shields.io/npm/v/@hypabolic/pi-hypa?color=cb3837&logo=npm)](https://www.npmjs.com/package/@hypabolic/pi-hypa)
+[![CI](https://github.com/Hypabolic/Hypa/actions/workflows/ci.yml/badge.svg)](https://github.com/Hypabolic/Hypa/actions/workflows/ci.yml)
+[![GitHub](https://img.shields.io/github/stars/Hypabolic/Hypa?style=flat&logo=github)](https://github.com/Hypabolic/Hypa)
+[![License](https://img.shields.io/badge/license-FSL--1.1--ALv2-blue)](https://github.com/Hypabolic/Hypa/blob/main/license.md)
 
-- bash rewrite interception via `hypa rewrite --json`
-- `/hypa` diagnostics
-- CLI-backed tools: `hypa_shell`, `hypa_read`, `hypa_grep`, `hypa_find`, `hypa_ls`
-- optional Hypa MCP proxy discovery tool: `hypa_mcp_proxy`
+`@hypabolic/pi-hypa` wires [Hypa](https://github.com/Hypabolic/Hypa) into the [Pi coding agent](https://www.npmjs.com/package/@earendil-works/pi-coding-agent). Hypa reduces the noisy tool output that reaches an agent's context window: it runs locally, compresses shell output with deterministic reducers, exposes context-aware file and code tools, and records enough evidence to recover the details that matter.
 
-Bash interception mutates the Pi `bash` command before execution when Hypa returns `Rewritten` or `GenericWrapper`.
+```text
+Pi bash / tool call
+        ↓
+      Hypa
+        ↓
+errors · warnings · changed files · failing tests · exit codes
+```
 
-## Install / smoke
+Hypa is not an LLM summarizer. The default reduction path is local, deterministic, and testable — your source code and command output do not need to be sent to a separate cloud service.
+
+## What this extension adds
+
+Installing this package through Pi also installs `@hypabolic/hypa` as a package dependency and creates a best-effort user-level `hypa` shim when no `hypa` command is already on `PATH`. The shim delegates to a later global/system `hypa` install if one appears earlier on `PATH`, and otherwise falls back to the bundled dependency.
+
+The extension provides:
+
+- **Bash rewrite interception** via `hypa rewrite --json` — Pi's `bash` command is mutated before execution when Hypa returns `Rewritten` or `GenericWrapper`, so command output is compressed in place.
+- **`/hypa` diagnostics** — inspect extension mode, binary resolution, MCP proxy setting, and the last rewrite status.
+- **CLI-backed tools** — `hypa_shell`, `hypa_read`, `hypa_grep`, `hypa_find`, `hypa_ls`.
+- **Optional Hypa MCP proxy** — the `hypa_mcp_proxy` discovery tool for upstream MCP servers.
+
+## Install
+
+This extension is installed automatically when you run `hypa init --agent pi` (or `hypa init` with Pi detected). To install or test it directly:
 
 ```bash
 pi -e ./packages/pi-hypa/extensions/index.ts
 # or
 pi install ./packages/pi-hypa
-# after release
+# from npm
 pi install npm:@hypabolic/pi-hypa
 ```
+
+### Requirements
+
+- Pi with the `@earendil-works/pi-coding-agent` peer dependency.
+- Node.js 18 or newer.
+- Linux, macOS, or Windows on x64 or arm64 (the bundled `@hypabolic/hypa` selects the matching native binary).
 
 ## Configuration
 
@@ -33,6 +60,20 @@ pi install npm:@hypabolic/pi-hypa
 | `HYPA_PI_ENABLE_MCP` | unset | Legacy alias for `HYPA_PI_ENABLE_MCP_PROXY` if needed. |
 | `HYPA_PI_MCP_PROXY_TIMEOUT_MS` | `10000` | Timeout for `hypa mcp ...` proxy calls. |
 | `HYPA_PI_MCP_CONFIG` | `~/.pi/agent/mcp.json` | Pi MCP config path used to deduplicate Hypa upstream servers already configured directly in Pi. |
+
+## CLI-backed tools
+
+When registered, the extension exposes Hypa-backed equivalents of Pi's file and shell builtins. In `additive` mode they sit alongside Pi's own tools; in `replace` mode they take over.
+
+| Tool | Purpose |
+|---|---|
+| `hypa_shell` | Run shell commands with rewrite rules, compression, and evidence recording. |
+| `hypa_read` | Read files with full, outline, signatures, pruned, or smart selection. |
+| `hypa_grep` | Search file contents with safe ripgrep options. |
+| `hypa_find` | Find files with an optional result limit. |
+| `hypa_ls` | List directory contents. |
+
+`hypa_*` tool outputs are capped at 50KB / 2000 lines; truncated full output is saved to a temp file for recovery.
 
 ## MCP proxy discovery
 
@@ -57,5 +98,17 @@ Run `/hypa` in Pi to show extension mode, binary resolution, MCP proxy setting, 
 - Commands already starting with `hypa` are not rewritten.
 - Parse, timeout, or process errors fail open by passing the original command through and recording diagnostics.
 - `Deny` blocks the tool call.
-- `Ask` confirms in UI mode and uses deterministic non-UI fallback.
+- `Ask` confirms in UI mode and uses a deterministic non-UI fallback.
 - `hypa_*` tool outputs are capped at 50KB / 2000 lines; truncated full output is saved to a temp file.
+
+## Documentation
+
+- [Pi integration guide](https://github.com/Hypabolic/Hypa/blob/main/docs/guides/pi.md)
+- [Hypa documentation](https://hypabolic.dev/products/hypa/docs)
+- [GitHub repository](https://github.com/Hypabolic/Hypa)
+- [`@hypabolic/hypa` on npm](https://www.npmjs.com/package/@hypabolic/hypa)
+- [Issue tracker](https://github.com/Hypabolic/Hypa/issues)
+
+## License
+
+Hypa is licensed under the [Functional Source License 1.1 with an Apache License 2.0 future license](https://github.com/Hypabolic/Hypa/blob/main/license.md).


### PR DESCRIPTION
## Summary

Two release-pipeline follow-ups after v0.1.5.

### Fix Pi package publish (`bug`)
The `@hypabolic/pi-hypa` auto-publish failed on the v0.1.5 release. It now triggers via `workflow_run` after the Release workflow completes, which runs in the default-branch context — so `GITHUB_REF_NAME` was `main`, not the tag, and the version-resolve step threw `Tag must be vX.Y.Z. Got 'main'.` The step now reads the tag from `github.event.workflow_run.head_branch` before falling back to `GITHUB_REF_NAME`. (`workflow_dispatch` was unaffected and remains the recovery path.)

### Expand the pi-hypa npm README
The published `@hypabolic/pi-hypa` README was a brief setup stub. It now leads with the Hypa overview, badges, and value proposition (matching `@hypabolic/hypa`) and adds Install, Requirements, CLI-backed tools, Documentation, and License sections, so the npm page presents the full picture rather than just basic setup.

## Notes
- `@hypabolic/hypa`'s npm README is already the full version (363 lines) as of v0.1.5.
- After this merges, `@hypabolic/pi-hypa@0.1.5` will be published via `workflow_dispatch` (it picks up the expanded README from the default branch).