### PR TITLE
Improve the pi-hypa package introduction

### DIFF
--- a/packages/pi-hypa/package.json
+++ b/packages/pi-hypa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hypabolic/pi-hypa",
   "version": "0.1.0",
-  "description": "Pi extension for Hypa command rewrite and CLI-backed tools",
+  "description": "Pi extension that keeps noisy tool output out of your context window. Automatically rewrites shell commands through Hypa for local, deterministic compression, context-aware file tools, and recoverable evidence.",
   "homepage": "https://github.com/Hypabolic/Hypa#readme",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- replace the terse implementation-focused npm description with a benefit-focused introduction
- explain that the Pi extension reduces noisy context through local deterministic compression
- highlight context-aware file tools and recoverable evidence

## Rationale

The existing package description only named internal mechanisms and did not clearly explain what the extension does for Pi users. Package listings now provide a more descriptive introduction comparable to other Pi plugins.

## Validation

- `git diff --check`
- `npm pack --dry-run --ignore-scripts` using an isolated temporary npm cache
