### PR TITLE
Improve pi-hypa tool UI rendering

### DIFF
--- a/packages/pi-hypa/extensions/tools.ts
+++ b/packages/pi-hypa/extensions/tools.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Text } from "@earendil-works/pi-tui";
 import type { HypaPiConfig } from "./types.js";
 
 const DEFAULT_MAX_BYTES = 50 * 1024;
@@ -217,6 +218,105 @@ function splitRawCommand(command: string): string[] {
   return command.trim().split(/\s+/).filter(Boolean);
 }
 
+function hasOwn(obj: unknown, key: string): boolean {
+  return !!obj && typeof obj === "object" && Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function pushParam(parts: string[], args: Record<string, unknown>, key: string) {
+  if (!hasOwn(args, key)) return;
+  const value = args[key];
+  if (value === true) {
+    parts.push(key);
+  } else if (value === false) {
+    parts.push(`${key}=false`);
+  } else if (typeof value === "string" && value.length > 0) {
+    parts.push(`${key}=${value}`);
+  } else if (typeof value === "number") {
+    parts.push(`${key}=${value}`);
+  }
+}
+
+function renderCallLine(title: string, main: string[], extras: string[], theme: any) {
+  const body = main.filter((part) => part.length > 0).join(" ");
+  const meta = extras.length > 0 ? ` ${theme.fg("muted", `(${extras.join(", ")})`)}` : "";
+  return new Text(`${theme.fg("toolTitle", theme.bold(title))}${body}${meta}`, 0, 0);
+}
+
+function renderHypaShellCall(args: Record<string, unknown>, theme: any) {
+  const main = [typeof args.command === "string" ? args.command : "..."];
+  const extras: string[] = [];
+  pushParam(extras, args, "raw");
+  pushParam(extras, args, "timeoutMs");
+  return renderCallLine("hypa_shell $ ", main, extras, theme);
+}
+
+function renderHypaReadCall(args: Record<string, unknown>, theme: any) {
+  const main = [typeof args.path === "string" ? args.path : "..."];
+  const extras: string[] = [];
+  pushParam(extras, args, "offset");
+  pushParam(extras, args, "limit");
+  pushParam(extras, args, "maxTokens");
+  return renderCallLine("hypa_read ", main, extras, theme);
+}
+
+function renderHypaGrepCall(args: Record<string, unknown>, theme: any) {
+  const main = [typeof args.pattern === "string" ? args.pattern : "...", typeof args.path === "string" ? args.path : ""];
+  const extras: string[] = [];
+  pushParam(extras, args, "glob");
+  pushParam(extras, args, "ignoreCase");
+  pushParam(extras, args, "literal");
+  pushParam(extras, args, "context");
+  pushParam(extras, args, "limit");
+  pushParam(extras, args, "timeoutMs");
+  return renderCallLine("hypa_grep ", main, extras, theme);
+}
+
+function renderHypaFindCall(args: Record<string, unknown>, theme: any) {
+  const main = [typeof args.pattern === "string" ? args.pattern : "", typeof args.path === "string" ? args.path : ""];
+  const extras: string[] = [];
+  pushParam(extras, args, "limit");
+  pushParam(extras, args, "timeoutMs");
+  return renderCallLine("hypa_find ", main, extras, theme);
+}
+
+function renderHypaLsCall(args: Record<string, unknown>, theme: any) {
+  const main = [typeof args.path === "string" ? args.path : ""];
+  const extras: string[] = [];
+  pushParam(extras, args, "all");
+  pushParam(extras, args, "long");
+  pushParam(extras, args, "timeoutMs");
+  return renderCallLine("hypa_ls ", main, extras, theme);
+}
+
+function previewResultText(result: any, options: { expanded?: boolean; isPartial?: boolean }, theme: any, pendingText: string) {
+  if (options?.isPartial) {
+    return new Text(theme.fg("muted", pendingText), 0, 0);
+  }
+
+  const output = Array.isArray(result?.content)
+    ? result.content.filter((part: any) => part?.type === "text").map((part: any) => part.text).join("\n")
+    : "";
+
+  if (!output) {
+    return new Text(theme.fg("muted", "(no output)"), 0, 0);
+  }
+
+  const styleOutput = (text: string) => text.split("\n").map((line: string) => theme.fg("toolOutput", line)).join("\n");
+
+  if (options?.expanded) {
+    return new Text(styleOutput(output), 0, 0);
+  }
+
+  const lines = output.split("\n");
+  if (lines.length <= 12) {
+    return new Text(styleOutput(output), 0, 0);
+  }
+
+  const preview = styleOutput(lines.slice(0, 12).join("\n"));
+  const hint = `\n${theme.fg("muted", `... (${lines.length - 12} more lines, Ctrl+O to expand)`)}`;
+  return new Text(`${preview}${hint}`, 0, 0);
+}
+
 async function toToolText(result: HypaExecResult, command: string, preferTail = false) {
   const combined = [result.stdout, result.stderr].filter((part) => part?.length > 0).join(result.stdout && result.stderr ? "\n" : "");
   const truncation = preferTail
@@ -264,6 +364,12 @@ export function registerHypaTools(pi: PiApi, config: HypaPiConfig) {
       const result = await runHypaCommand(pi, config, params.command, params.timeoutMs, params.raw, signal);
       return toToolText(result, params.command, true);
     },
+    renderCall(args: any, theme: any) {
+      return renderHypaShellCall(args ?? {}, theme);
+    },
+    renderResult(result: any, options: any, theme: any) {
+      return previewResultText(result, options ?? {}, theme, "Running Hypa shell command...");
+    },
   });
 
   pi.registerTool({
@@ -279,6 +385,12 @@ export function registerHypaTools(pi: PiApi, config: HypaPiConfig) {
       const result = await runHypaCommand(pi, config, command, timeoutMs, false, signal);
       return toToolText(result, command);
     },
+    renderCall(args: any, theme: any) {
+      return renderHypaReadCall(args ?? {}, theme);
+    },
+    renderResult(result: any, options: any, theme: any) {
+      return previewResultText(result, options ?? {}, theme, "Reading file through Hypa...");
+    },
   });
 
   pi.registerTool({
@@ -291,6 +403,12 @@ export function registerHypaTools(pi: PiApi, config: HypaPiConfig) {
       const command = buildGrepCommand(params as { pattern: string; path?: string; glob?: string; ignoreCase?: boolean; literal?: boolean; context?: number; limit?: number });
       const result = await runHypaCommand(pi, config, command, params.timeoutMs, false, signal);
       return toToolText(result, command);
+    },
+    renderCall(args: any, theme: any) {
+      return renderHypaGrepCall(args ?? {}, theme);
+    },
+    renderResult(result: any, options: any, theme: any) {
+      return previewResultText(result, options ?? {}, theme, "Searching through Hypa...");
     },
   });
 
@@ -305,6 +423,12 @@ export function registerHypaTools(pi: PiApi, config: HypaPiConfig) {
       const result = await runHypaCommand(pi, config, command, params.timeoutMs, false, signal);
       return toToolText(result, command);
     },
+    renderCall(args: any, theme: any) {
+      return renderHypaFindCall(args ?? {}, theme);
+    },
+    renderResult(result: any, options: any, theme: any) {
+      return previewResultText(result, options ?? {}, theme, "Finding files through Hypa...");
+    },
   });
 
   pi.registerTool({
@@ -317,6 +441,12 @@ export function registerHypaTools(pi: PiApi, config: HypaPiConfig) {
       const command = buildLsCommand(params);
       const result = await runHypaCommand(pi, config, command, params.timeoutMs, false, signal);
       return toToolText(result, command);
+    },
+    renderCall(args: any, theme: any) {
+      return renderHypaLsCall(args ?? {}, theme);
+    },
+    renderResult(result: any, options: any, theme: any) {
+      return previewResultText(result, options ?? {}, theme, "Listing directory through Hypa...");
     },
   });
 }

--- a/packages/pi-hypa/package-lock.json
+++ b/packages/pi-hypa/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "FSL-1.1-ALv2",
       "dependencies": {
+        "@earendil-works/pi-tui": "^0.79.8",
         "@hypabolic/hypa": "0.1.3"
       },
       "devDependencies": {
@@ -676,6 +677,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -692,6 +696,9 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -710,6 +717,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -727,6 +737,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -743,6 +756,9 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1979,6 +1995,19 @@
         "zod": "^3.25.28 || ^4"
       }
     },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.79.8",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.8.tgz",
+      "integrity": "sha512-QerB+0wUc6eEO8MwvzOQGtzcsbwo6y8VvdxYU6vGcakz6ofJZWhrmwrknp1dCGx3bEtCf+siUIxEzkqvFCzIsg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
@@ -2608,6 +2637,30 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/tsx": {

--- a/packages/pi-hypa/package.json
+++ b/packages/pi-hypa/package.json
@@ -31,6 +31,7 @@
     "postinstall": "node scripts/postinstall.js"
   },
   "dependencies": {
+    "@earendil-works/pi-tui": "^0.79.8",
     "@hypabolic/hypa": "0.1.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

This PR adds minimal UI-only rendering improvements for:

- `hypa_shell`
- `hypa_read`
- `hypa_grep`
- `hypa_find`
- `hypa_ls`

## Changes

- add `renderCall(...)` so tool invocations show their actual input arguments
- add `renderResult(...)` so long tool output is previewed in collapsed form
- show a simple expand hint for long output

## Non-goals

This PR does **not** change:

- tool execution semantics
- command construction
- schemas
- truncation generation logic
- wrapper behavior

## Note

This branch works in the installed Pi runtime environment used for local testing.

However, syncing the same implementation back into the package source currently exposes an extension integration issue around directly importing Pi TUI components from `pi-hypa` package source. A separate issue is linked for that discussion.

Related issue: #24
