### PR TITLE
Fix hypa shim creation when npm transiently adds node_modules/.bin to PATH

### DIFF
--- a/packages/pi-hypa/scripts/postinstall.js
+++ b/packages/pi-hypa/scripts/postinstall.js
@@ -18,12 +18,24 @@ function isLocalDevelopmentInstall() {
   }
 }
 
+// npm prepends the package's `node_modules/.bin` to PATH while running
+// lifecycle scripts. During this postinstall that directory already contains a
+// `hypa` entry from the bundled `@hypabolic/hypa` dependency, so scanning it
+// would make `commandExists("hypa")` a false positive and wrongly skip the
+// user-level shim install. Ignore those transient `.bin` directories; the shim
+// itself already delegates to any real `hypa` that appears on PATH at runtime.
+function isNodeModulesBinDir(dir) {
+  const normalized = dir.replace(/[\\/]+$/, "");
+  return normalized.endsWith(join("node_modules", ".bin"));
+}
+
 function commandExists(command) {
   const path = process.env.PATH;
   if (!path) return false;
   const isWindows = platform() === "win32";
   for (const dir of path.split(isWindows ? ";" : ":")) {
     if (!dir) continue;
+    if (isNodeModulesBinDir(dir)) continue;
     if (existsSync(join(dir, command))) return true;
     if (isWindows && existsSync(join(dir, `${command}.cmd`))) return true;
     if (isWindows && existsSync(join(dir, `${command}.exe`))) return true;


### PR DESCRIPTION
## What

Fixes the `pi-hypa` postinstall so it actually creates the user-level `hypa` shim at `~/.local/bin/hypa`.

Closes #28.

## Why

`scripts/postinstall.js` skips shim creation when `commandExists("hypa")` is true:

```js
if (commandExists("hypa")) { /* skip shim */ process.exit(0); }
```

During `npm install`, npm prepends the package's transient `node_modules/.bin` to `PATH`, and that directory already contains a `hypa` entry from the bundled `@hypabolic/hypa` dependency. So `commandExists("hypa")` is a **false positive at install time** and the real user-level shim is never written.

Once install finishes, `node_modules/.bin` is gone from PATH. Pi's bash-rewrite interception then emits a bare `hypa -c "..."`, which cannot be resolved, so **every Pi `bash` tool call fails** with `hypa: command not found` (exit 127). (The `hypa_*` tools keep working because they call the resolved binary directly via `pi.exec`, which is why the failure looks unrelated at first.)

## The fix

Ignore any `node_modules/.bin` directory while scanning PATH in `commandExists()`. The runtime shim already delegates to any genuine `hypa` it finds earlier on PATH, so always creating it is safe even when an external `hypa` is installed later.

```js
function isNodeModulesBinDir(dir) {
  const normalized = dir.replace(/[\\/]+$/, "");
  return normalized.endsWith(join("node_modules", ".bin"));
}
// ... in commandExists: `if (isNodeModulesBinDir(dir)) continue;`
```

## Testing

- `node --check` passes.
- Verified `isNodeModulesBinDir` against `node_modules/.bin`, trailing-slash and `//` variants, and normal bin dirs (`/usr/local/bin`, `~/.local/bin`).
- Manually reproduced the original failure and confirmed re-running the postinstall (with `.bin` excluded) creates `~/.local/bin/hypa` and restores Pi bash calls.

## Notes

No existing tests cover `postinstall.js` (its helpers are not exported and it runs side-effects on import), so none were updated. Happy to refactor the script to export helpers for unit testing if maintainers prefer.
