### PR TITLE
Fix GenericWrapperEnabled binding in JsonConfigLoader

### DIFF
--- a/src/Hypa.Infrastructure/Config/JsonConfigLoader.cs
+++ b/src/Hypa.Infrastructure/Config/JsonConfigLoader.cs
@@ -49,6 +49,7 @@ public sealed class JsonConfigLoader : IConfigLoader
         var enabled = cfg["enabled"];
         var storagePath = cfg["storage_path"];
         var logLevel = cfg["log_level"];
+        var genericWrapperEnabled = cfg["generic_wrapper_enabled"];
         var showCompressionMetadata = cfg["show_compression_metadata"];
 
         var excludeChildren = cfg.GetSection("exclude_commands").GetChildren().ToArray();
@@ -70,6 +71,9 @@ public sealed class JsonConfigLoader : IConfigLoader
                 ? Enum.TryParse<LogLevel>(logLevel, ignoreCase: true, out var ll) ? ll : defaults.LogLevel
                 : defaults.LogLevel,
             ExcludeCommands = excludeCommands,
+            GenericWrapperEnabled = genericWrapperEnabled is not null
+                ? bool.TryParse(genericWrapperEnabled, out var gwe) ? gwe : defaults.GenericWrapperEnabled
+                : defaults.GenericWrapperEnabled,
             ShowCompressionMetadata = showCompressionMetadata is not null
                 ? bool.TryParse(showCompressionMetadata, out var scm) ? scm : defaults.ShowCompressionMetadata
                 : defaults.ShowCompressionMetadata,

--- a/tests/Hypa.UnitTests/Infrastructure/JsonConfigLoaderTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/JsonConfigLoaderTests.cs
@@ -117,6 +117,18 @@ public sealed class JsonConfigLoaderTests : IDisposable
     }
 
     [Fact]
+    public async Task LoadAsync_GenericWrapperEnabled_BindsFalse()
+    {
+        WriteJson(Path.Combine(_tempDir, "config.json"), new { generic_wrapper_enabled = false });
+
+        var loader = new JsonConfigLoader(_noRootDetector, _tempDir);
+        var result = await loader.LoadAsync(CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.False(result.Value.GenericWrapperEnabled);
+    }
+
+    [Fact]
     public async Task LoadAsync_UpdateChannel_BindsCustomValue()
     {
         WriteJson(Path.Combine(_tempDir, "config.json"), new { update_channel = "nightly" });
@@ -162,6 +174,16 @@ public sealed class JsonConfigLoaderTests : IDisposable
         Assert.True(result.Value.UpdateCheckEnabled);
         Assert.Equal("stable", result.Value.UpdateChannel);
         Assert.Equal("Hypabolic/Hypa", result.Value.ReleaseRepository);
+    }
+
+    [Fact]
+    public async Task LoadAsync_GenericWrapperEnabled_DefaultIsTrue()
+    {
+        var loader = new JsonConfigLoader(_noRootDetector, _tempDir);
+        var result = await loader.LoadAsync(CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.True(result.Value.GenericWrapperEnabled);
     }
 
     private static void WriteJson(string path, object obj)


### PR DESCRIPTION
## What

Fixes `generic_wrapper_enabled` being silently ignored when set in `~/.hypa/config.json`.

Closes #27.

## Why

`BindConfig` in `JsonConfigLoader.cs` maps each config key by hand but was missing a binding for `generic_wrapper_enabled`. As a result `HypaConfig.GenericWrapperEnabled` always stayed at its default of `true`, regardless of what was set in config or via the `HYPA_GENERIC_WRAPPER_ENABLED` env var.

## The fix

Added the missing binding following the exact same `TryParse` pattern as the other bool keys (`enabled`, `update_check_enabled`, `show_compression_metadata`):

```csharp
var genericWrapperEnabled = cfg["generic_wrapper_enabled"];
GenericWrapperEnabled = genericWrapperEnabled is not null
    ? bool.TryParse(genericWrapperEnabled, out var gwe) ? gwe : defaults.GenericWrapperEnabled
    : defaults.GenericWrapperEnabled,
```

Since `AddEnvironmentVariables("HYPA_")` is already called, this also enables the `HYPA_GENERIC_WRAPPER_ENABLED` env var override at no extra cost.

## Tests

Added two unit tests to `JsonConfigLoaderTests`:
- `LoadAsync_GenericWrapperEnabled_BindsFalse` — asserts config file `false` is honoured
- `LoadAsync_GenericWrapperEnabled_DefaultIsTrue` — asserts default remains `true` when unset

All 12 `JsonConfigLoaderTests` pass.