### PR TITLE
Fix spawn EFTYPE on Windows when executing Hypa tools via Pi

### DIFF
--- a/packages/pi-hypa/extensions/rewrite-client.ts
+++ b/packages/pi-hypa/extensions/rewrite-client.ts
@@ -6,6 +6,24 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { HypaPiConfig, RewriteStatus } from "./types.js";
 import { isHypaCommand, mapRewriteResult, parseRewriteJson } from "./policy.js";
 
+/**
+ * Normalises a resolved binary path + its arguments for the current platform.
+ *
+ * On Windows, Node.js cannot `spawn` a `.js` file directly (no shebang support)
+ * or a `.cmd` shell script without a shell — both produce `EFTYPE`. Wrap them
+ * with the appropriate interpreter so `pi.exec` always receives a native binary.
+ */
+export function getExecArgs(
+  binary: string,
+  args: string[],
+  platformName: string = platform(),
+): [string, string[]] {
+  if (platformName !== "win32") return [binary, args];
+  if (binary.endsWith(".js")) return ["node", [binary, ...args]];
+  if (binary.endsWith(".cmd")) return ["cmd", ["/c", binary, ...args]];
+  return [binary, args];
+}
+
 const require = createRequire(import.meta.url);
 
 export function resolveHypaBinary(binary: string, env: NodeJS.ProcessEnv = process.env): string {
@@ -60,7 +78,8 @@ export async function rewriteCommand(
   }
 
   try {
-    const result = await pi.exec(config.binary, ["rewrite", "--json", command], {
+    const [execBin, execArgs] = getExecArgs(config.binary, ["rewrite", "--json", command]);
+    const result = await pi.exec(execBin, execArgs, {
       signal,
       timeout: config.rewriteTimeoutMs,
     });

--- a/packages/pi-hypa/extensions/tools.ts
+++ b/packages/pi-hypa/extensions/tools.ts
@@ -2,6 +2,7 @@ import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { HypaPiConfig } from "./types.js";
+import { getExecArgs } from "./rewrite-client.js";
 
 const DEFAULT_MAX_BYTES = 50 * 1024;
 const DEFAULT_MAX_LINES = 2000;
@@ -208,7 +209,8 @@ async function runHypaCommand(
   } else {
     args.push("-c", command);
   }
-  return pi.exec(config.binary, args, { signal, timeout: timeoutMs });
+  const [execBin, execArgs] = getExecArgs(config.binary, args);
+  return pi.exec(execBin, execArgs, { signal, timeout: timeoutMs });
 }
 
 function splitRawCommand(command: string): string[] {

--- a/packages/pi-hypa/test/rewrite-client.test.ts
+++ b/packages/pi-hypa/test/rewrite-client.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { resolveHypaBinary, rewriteCommand } from "../extensions/rewrite-client.js";
+import { resolveHypaBinary, rewriteCommand, getExecArgs } from "../extensions/rewrite-client.js";
 import type { HypaPiConfig } from "../extensions/types.js";
 
 const config: HypaPiConfig = {
@@ -52,4 +52,23 @@ test("rewriteCommand fails safe on timeout", async () => {
   const status = await rewriteCommand(fakePi("", { killed: true }), config, "git status");
   assert.equal(status.kind, "error");
   assert.match(status.kind === "error" ? status.error : "", /timed out/);
+});
+
+test("getExecArgs wraps Windows .js binaries with node", () => {
+  assert.deepEqual(getExecArgs("/path/to/bin.js", ["-c", "echo hi"], "win32"), [
+    "node",
+    ["/path/to/bin.js", "-c", "echo hi"],
+  ]);
+});
+
+test("getExecArgs wraps Windows .cmd binaries with cmd", () => {
+  assert.deepEqual(getExecArgs("C:\\hypa.cmd", ["arg"], "win32"), ["cmd", ["/c", "C:\\hypa.cmd", "arg"]]);
+});
+
+test("getExecArgs passes through Windows .exe binaries", () => {
+  assert.deepEqual(getExecArgs("hypa.exe", ["arg"], "win32"), ["hypa.exe", ["arg"]]);
+});
+
+test("getExecArgs passes through non-Windows .js binaries", () => {
+  assert.deepEqual(getExecArgs("/path/bin.js", ["arg"], "linux"), ["/path/bin.js", ["arg"]]);
 });


### PR DESCRIPTION
## What

Fixes all Hypa tools failing with `spawn EFTYPE` when Pi is used on Windows.

Closes #23.

## Why

`pi.exec(binary, args)` ultimately calls Node.js `child_process.spawn(binary, args)`. On Windows, spawning a `.js` file directly fails with `EFTYPE` (error 79: inappropriate file type) because Windows has no shebang support — unlike Unix where `#!/usr/bin/env node` transparently delegates to Node. The same issue affects `.cmd` shims resolved from PATH.

The resolved binary shown in the issue (`C:\...\@hypabolic\hypa\bin.js`) confirms this is the bundled-binary fallback path hitting the problem.

## The fix

Add `getExecArgs(binary, args, platform?)` in `rewrite-client.ts` that normalises the spawn target on Windows:

| Resolved binary | Becomes |
|---|---|
| `*.js` | `node [\*.js, ...args]` |
| `*.cmd` | `cmd [/c, \*.cmd, ...args]` |
| `*.exe` / non-Windows | unchanged |

Use `getExecArgs` in both `rewriteCommand` (rewrite-client.ts) and `runHypaCommand` (tools.ts) so every `pi.exec` call-site is covered.

## Tests

Added 4 unit tests for `getExecArgs` covering all branches. All 30 package tests pass.