### PR TITLE
Address Copilot review comments from #34

### DIFF
--- a/packages/pi-hypa/extensions/mcp-proxy-bridge.ts
+++ b/packages/pi-hypa/extensions/mcp-proxy-bridge.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { HypaPiConfig } from "./types.js";
+import { getExecArgs } from "./rewrite-client.js";
 
 type PiToolParams = Record<string, any>;
 type HypaExecResult = { stdout: string; stderr: string; code: number; killed?: boolean };
@@ -152,7 +153,8 @@ async function runHypaMcpJson<T>(
   signal?: AbortSignal,
 ): Promise<T> {
   const timeout = timeoutMs ?? config.mcpProxyTimeoutMs;
-  const result = await pi.exec(config.binary, ["mcp", ...args], { signal, timeout });
+  const [execBin, execArgs] = getExecArgs(config.binary, ["mcp", ...args]);
+  const result = await pi.exec(execBin, execArgs, { signal, timeout });
   return parseJson<T>(result, `hypa mcp ${args.join(" ")}`);
 }
 

--- a/packages/pi-hypa/extensions/policy.ts
+++ b/packages/pi-hypa/extensions/policy.ts
@@ -26,7 +26,7 @@ export function parseBooleanFlag(value: string | undefined): boolean {
 
 export function resolveConfigFilePath(env: NodeJS.ProcessEnv): string | undefined {
   const fromEnv = env.HYPA_PI_CONFIG?.trim();
-  if (fromEnv === "" || fromEnv === "none") return undefined;
+  if (fromEnv === "" || fromEnv.toLowerCase() === "none") return undefined;
   if (fromEnv) return fromEnv;
   return path.join(os.homedir(), ".hypa-pi", "config.json");
 }

--- a/packages/pi-hypa/extensions/rewrite-client.ts
+++ b/packages/pi-hypa/extensions/rewrite-client.ts
@@ -19,8 +19,9 @@ export function getExecArgs(
   platformName: string = platform(),
 ): [string, string[]] {
   if (platformName !== "win32") return [binary, args];
-  if (binary.endsWith(".js")) return ["node", [binary, ...args]];
-  if (binary.endsWith(".cmd")) return ["cmd", ["/c", binary, ...args]];
+  const lower = binary.toLowerCase();
+  if (lower.endsWith(".js")) return ["node", [binary, ...args]];
+  if (lower.endsWith(".cmd") || lower.endsWith(".bat")) return ["cmd", ["/c", binary, ...args]];
   return [binary, args];
 }
 

--- a/packages/pi-hypa/test/policy.test.ts
+++ b/packages/pi-hypa/test/policy.test.ts
@@ -140,3 +140,12 @@ test("loadConfigFile throws a descriptive error on malformed JSON", () => {
   writeFileSync(configPath, '{ "mode": "replace", }');
   assert.throws(() => loadConfigFile(configPath), /Failed to parse config file.*malformed\.json/);
 });
+
+test("loadConfig treats HYPA_PI_CONFIG=none and NONE and None as disable", () => {
+  const configPath = join(tempRoot, "should-not-load.json");
+  writeFileSync(configPath, JSON.stringify({ mode: "replace" }));
+  for (const sentinel of ["none", "NONE", "None"]) {
+    const config = loadConfig({ HYPA_PI_CONFIG: sentinel });
+    assert.equal(config.mode, "additive", `sentinel "${sentinel}" should disable config file`);
+  }
+});

--- a/packages/pi-hypa/test/rewrite-client.test.ts
+++ b/packages/pi-hypa/test/rewrite-client.test.ts
@@ -72,3 +72,15 @@ test("getExecArgs passes through Windows .exe binaries", () => {
 test("getExecArgs passes through non-Windows .js binaries", () => {
   assert.deepEqual(getExecArgs("/path/bin.js", ["arg"], "linux"), ["/path/bin.js", ["arg"]]);
 });
+
+test("getExecArgs wraps Windows .bat binaries with cmd", () => {
+  assert.deepEqual(getExecArgs("C:\\hypa.bat", ["arg"], "win32"), ["cmd", ["/c", "C:\\hypa.bat", "arg"]]);
+});
+
+test("getExecArgs wraps Windows uppercase .JS binaries with node", () => {
+  assert.deepEqual(getExecArgs("/path/to/bin.JS", ["arg"], "win32"), ["node", ["/path/to/bin.JS", "arg"]]);
+});
+
+test("getExecArgs wraps Windows uppercase .CMD binaries with cmd", () => {
+  assert.deepEqual(getExecArgs("C:\\hypa.CMD", ["arg"], "win32"), ["cmd", ["/c", "C:\\hypa.CMD", "arg"]]);
+});


### PR DESCRIPTION
Follow-up to #34 addressing the valid Copilot review comments:

**Fixed:**
- **Case-insensitive `none` sentinel** (`policy.ts`): `HYPA_PI_CONFIG=NONE` / `None` / `none` all now disable config file loading.
- **`.bat` and uppercase extensions in `getExecArgs`** (`rewrite-client.ts`): Windows `.bat` wrapper scripts are now handled, and extension matching is case-insensitive (`.JS`, `.CMD`, `.BAT` all work).
- **MCP proxy bypassing `getExecArgs`** (`mcp-proxy-bridge.ts`): `runHypaMcpJson` now routes through `getExecArgs` so Windows `.js`/`.cmd`/`.bat` shims don't produce `EFTYPE` errors in MCP proxy calls.

**Not changed (by design):**
- `loadConfigFile` still throws on malformed JSON with a descriptive message. Silently swallowing a parse error would hide user typos and make config failures undiagnosable. The descriptive error is intentional.
- C# `JsonConfigLoader` changes were already merged with #34 and are out of scope here.