### PR TITLE
Fix git hook rewrites for --no-pager

### DIFF
--- a/src/Hypa.Infrastructure/Rewrite/GitRewriteStrategy.cs
+++ b/src/Hypa.Infrastructure/Rewrite/GitRewriteStrategy.cs
@@ -6,18 +6,52 @@ namespace Hypa.Infrastructure.Rewrite;
 public sealed class GitRewriteStrategy : ICommandRewriteStrategy
 {
     private static readonly HashSet<string> Supported = ["status", "diff", "log"];
+    private static readonly HashSet<string> OptionsRequiringValue = ["-c", "-C", "--git-dir", "--work-tree", "--namespace"];
 
     public bool CanHandle(string verb) => verb == "git";
 
     public RewriteDecision Rewrite(IReadOnlyList<ShellToken> tokens, RewriteContext context)
     {
         var args = tokens.Where(t => t.Kind is TokenKind.Arg or TokenKind.QuotedArg).ToList();
-        var sub = args.Skip(1).FirstOrDefault();
+        var sub = FindSubcommand(args);
 
-        if (sub is null || !Supported.Contains(sub.Value))
+        if (sub is null || !Supported.Contains(sub))
             return RewriteDecision.Passthrough();
 
         var rest = string.Join(" ", args.Select(t => t.Value));
         return RewriteDecision.Rewritten($"hypa {rest}");
+    }
+
+    private static string? FindSubcommand(IReadOnlyList<ShellToken> args)
+    {
+        if (args.Count <= 1)
+            return null;
+
+        for (var i = 1; i < args.Count; i++)
+        {
+            var token = args[i];
+            var value = token.Value;
+
+            if (value == "--")
+                return null;
+
+            if (value.Length > 0 && value[0] == '-')
+            {
+                if (OptionsRequiringValue.Contains(value))
+                {
+                    i++;
+                    continue;
+                }
+
+                if (value is "--no-pager" or "-p")
+                    continue;
+
+                return null;
+            }
+
+            return value;
+        }
+
+        return null;
     }
 }

--- a/src/Hypa.Infrastructure/Rewrite/GitRewriteStrategy.cs
+++ b/src/Hypa.Infrastructure/Rewrite/GitRewriteStrategy.cs
@@ -7,6 +7,7 @@ public sealed class GitRewriteStrategy : ICommandRewriteStrategy
 {
     private static readonly HashSet<string> Supported = ["status", "diff", "log"];
     private static readonly HashSet<string> OptionsRequiringValue = ["-c", "-C", "--git-dir", "--work-tree", "--namespace"];
+    private static readonly HashSet<string> PagerOptions = ["--no-pager", "-P", "--paginate", "-p"];
 
     public bool CanHandle(string verb) => verb == "git";
 
@@ -43,7 +44,7 @@ public sealed class GitRewriteStrategy : ICommandRewriteStrategy
                     continue;
                 }
 
-                if (value is "--no-pager" or "-p")
+                if (PagerOptions.Contains(value))
                     continue;
 
                 return null;

--- a/tests/Hypa.UnitTests/Infrastructure/CommandRewriteRegistryTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/CommandRewriteRegistryTests.cs
@@ -41,6 +41,8 @@ public sealed class CommandRewriteRegistryTests
     [InlineData("git diff HEAD~1", "hypa git diff HEAD~1")]
     [InlineData("git log --oneline", "hypa git log --oneline")]
     [InlineData("git --no-pager diff --staged", "hypa git --no-pager diff --staged")]
+    [InlineData("git -P diff --staged", "hypa git -P diff --staged")]
+    [InlineData("git --paginate diff --staged", "hypa git --paginate diff --staged")]
     public void Git_SupportedSubcommand_ReturnsRewritten(string input, string expected)
     {
         var registry = BuildRegistry();

--- a/tests/Hypa.UnitTests/Infrastructure/CommandRewriteRegistryTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/CommandRewriteRegistryTests.cs
@@ -40,6 +40,7 @@ public sealed class CommandRewriteRegistryTests
     [InlineData("git status", "hypa git status")]
     [InlineData("git diff HEAD~1", "hypa git diff HEAD~1")]
     [InlineData("git log --oneline", "hypa git log --oneline")]
+    [InlineData("git --no-pager diff --staged", "hypa git --no-pager diff --staged")]
     public void Git_SupportedSubcommand_ReturnsRewritten(string input, string expected)
     {
         var registry = BuildRegistry();


### PR DESCRIPTION
## Summary
- update the git rewrite strategy to skip git global options like --no-pager before locating the actual subcommand
- add a regression test covering git --no-pager diff --staged in hook-driven rewrites

## Testing
- dotnet test tests/Hypa.UnitTests/Hypa.UnitTests.csproj --filter "FullyQualifiedName~CommandRewriteRegistryTests"
- dotnet format --verify-no-changes