### PR TITLE
Fix shell reserved word command rewrites

### DIFF
--- a/src/Hypa.Infrastructure/Rewrite/CommandRewriteRegistry.cs
+++ b/src/Hypa.Infrastructure/Rewrite/CommandRewriteRegistry.cs
@@ -23,10 +23,11 @@ public sealed class CommandRewriteRegistry(
         // Split on compound operators and rewrite each segment
         var segments = SplitOnOperators(tokens);
 
-        // A builtin that mutates shell state can't survive being split into separate
-        // `hypa -c` processes. If any segment is such a builtin, pass the whole
-        // command through unchanged to preserve exact shell semantics.
-        if (segments.Any(SegmentIsStatefulBuiltin))
+        // A builtin that mutates shell state or a shell reserved word can't
+        // survive being split into separate `hypa -c` processes. If any segment
+        // starts with one, pass the whole command through unchanged to preserve
+        // exact shell semantics.
+        if (segments.Any(SegmentRequiresWholeShell))
             return RewriteDecision.Passthrough();
 
         if (segments.Count == 1)
@@ -35,10 +36,10 @@ public sealed class CommandRewriteRegistry(
         return RewriteCompound(segments, context);
     }
 
-    private static bool SegmentIsStatefulBuiltin(Segment segment)
+    private static bool SegmentRequiresWholeShell(Segment segment)
     {
         var verb = ShellVerb.Extract(segment.Tokens);
-        return verb is not null && ShellBuiltins.IsStateful(verb);
+        return verb is not null && (ShellBuiltins.IsStateful(verb) || ShellReservedWords.IsReservedWord(verb));
     }
 
     private RewriteDecision RewriteSegment(

--- a/src/Hypa.Runtime/Domain/Rewrite/ShellReservedWords.cs
+++ b/src/Hypa.Runtime/Domain/Rewrite/ShellReservedWords.cs
@@ -1,0 +1,13 @@
+namespace Hypa.Runtime.Domain.Rewrite;
+
+public static class ShellReservedWords
+{
+    public static readonly IReadOnlySet<string> Values = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "!", "{", "}", "[[", "]]", "case", "coproc", "do", "done", "elif",
+        "else", "esac", "fi", "for", "function", "if", "in", "select",
+        "then", "time", "until", "while",
+    };
+
+    public static bool IsReservedWord(string verb) => Values.Contains(verb);
+}

--- a/tests/Hypa.UnitTests/Infrastructure/CommandRewriteRegistryTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/CommandRewriteRegistryTests.cs
@@ -192,6 +192,18 @@ public sealed class CommandRewriteRegistryTests
         Assert.Equal(RewriteOutcome.Passthrough, result.Outcome);
     }
 
+    [Theory]
+    [InlineData("for x in a b; do echo item; done")]
+    [InlineData("if [ -f package.json ]; then echo yes; fi")]
+    [InlineData("while true; do echo tick; break; done")]
+    [InlineData("case a in a) echo a ;; esac")]
+    public void CompoundCommand_WithShellReservedWords_ReturnsPassthrough(string input)
+    {
+        var registry = BuildRegistry();
+        var result = registry.Rewrite(input, DefaultContext);
+        Assert.Equal(RewriteOutcome.Passthrough, result.Outcome);
+    }
+
     [Fact]
     public void StatefulBuiltinNameInArgument_DoesNotReturnPassthrough()
     {


### PR DESCRIPTION
## Summary

- pass through compound shell commands whose segments start with shell reserved words
- prevent `hypa rewrite` from splitting `for`/`if`/`while`/`case` grammar into invalid `hypa -c` fragments
- keep existing compound rewrites such as `git status ; dotnet build` intact

## Verification

- `dotnet test tests/Hypa.UnitTests/Hypa.UnitTests.csproj --filter 'FullyQualifiedName~CommandRewriteRegistryTests'`
- `dotnet run --project src/Hypa.Cli/Hypa.Cli.csproj -- rewrite --json 'for x in a b; do echo "item:$x"; done'` returns `Passthrough`
- `dotnet run --project src/Hypa.Cli/Hypa.Cli.csproj -- rewrite --json 'if [ -f package.json ]; then echo yes; fi'` returns `Passthrough`
- `dotnet run --project src/Hypa.Cli/Hypa.Cli.csproj -- rewrite --json 'git status ; dotnet build'` still returns `Rewritten`

## Notes

Full `dotnet test tests/Hypa.UnitTests/Hypa.UnitTests.csproj` currently has an unrelated existing failure in `CodeStructureProviderRegistryTests.Select_ForMarkdown_ReturnsMarkdownProvider` where the provider resolves to `regex-fallback` instead of `markdown`.

`npm test` in `packages/pi-hypa` passes. `npm run build` currently fails on an existing strictness issue in `extensions/policy.ts(29,25): fromEnv is possibly undefined`.
