### PR TITLE
Document ShellReservedWords and add reserved-word arg test

### DIFF
--- a/src/Hypa.Runtime/Domain/Rewrite/ShellReservedWords.cs
+++ b/src/Hypa.Runtime/Domain/Rewrite/ShellReservedWords.cs
@@ -1,13 +1,18 @@
 namespace Hypa.Runtime.Domain.Rewrite;
 
+/// Shell grammar keywords that introduce or delimit compound constructs
+/// (loops, conditionals, brace groups, …). A segment starting with one of
+/// these cannot be split into a separate `hypa -c` process without producing
+/// invalid shell grammar, so any command containing one must be passed
+/// through unchanged.
 public static class ShellReservedWords
 {
-    public static readonly IReadOnlySet<string> Values = new HashSet<string>(StringComparer.Ordinal)
+    public static readonly IReadOnlySet<string> ReservedWords = new HashSet<string>(StringComparer.Ordinal)
     {
         "!", "{", "}", "[[", "]]", "case", "coproc", "do", "done", "elif",
         "else", "esac", "fi", "for", "function", "if", "in", "select",
         "then", "time", "until", "while",
     };
 
-    public static bool IsReservedWord(string verb) => Values.Contains(verb);
+    public static bool IsReservedWord(string verb) => ReservedWords.Contains(verb);
 }

--- a/tests/Hypa.UnitTests/Infrastructure/CommandRewriteRegistryTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/CommandRewriteRegistryTests.cs
@@ -205,6 +205,14 @@ public sealed class CommandRewriteRegistryTests
     }
 
     [Fact]
+    public void ShellReservedWordNameInArgument_DoesNotReturnPassthrough()
+    {
+        var registry = BuildRegistry();
+        var result = registry.Rewrite("echo for", DefaultContext);
+        Assert.Equal(RewriteOutcome.GenericWrapper, result.Outcome);
+    }
+
+    [Fact]
     public void StatefulBuiltinNameInArgument_DoesNotReturnPassthrough()
     {
         var registry = BuildRegistry();


### PR DESCRIPTION
## Summary

Follow-up polish to #43, aligning the new `ShellReservedWords` helper with the existing `ShellBuiltins` conventions and closing a small test gap.

- Add an explanatory XML doc comment to `ShellReservedWords`, mirroring the sibling `ShellBuiltins` type
- Rename the exposed set from `Values` to `ReservedWords` for clarity (no external references existed)
- Add a negative test proving a reserved word used as an argument (`echo for`) still rewrites via the generic wrapper rather than passing through

## Verification

- `dotnet test tests/Hypa.UnitTests/Hypa.UnitTests.csproj --filter 'FullyQualifiedName~CommandRewriteRegistryTests'` → 46 passed
- `dotnet format --verify-no-changes` on the changed files → clean

## Notes

This is a maintenance/refactor change; the repo has no `chore`/`maintenance`/`refactor` label, so `documentation` is applied as the closest existing category.