### PR TITLE
Expand command substitutions and heredocs inside quoted args in hypa -c

### DIFF
--- a/src/Hypa.Cli/Commands/RunCommand.cs
+++ b/src/Hypa.Cli/Commands/RunCommand.cs
@@ -85,6 +85,7 @@ public sealed class RunCommand(CommandRunnerService runnerService, IShellLexer s
         var verb = ShellVerb.Extract(lexed);
         var usesShellSyntax =
             lexed.Any(t => t.Kind is TokenKind.Operator or TokenKind.Pipe or TokenKind.Redirect or TokenKind.Shellism)
+            || ShellExpansion.ContainsExpansion(lexed)
             || ShellVerb.HasAssignmentPrefix(lexed)
             || (verb is not null && ShellBuiltins.IsStateful(verb));
 

--- a/src/Hypa.Runtime/Domain/Rewrite/ShellExpansion.cs
+++ b/src/Hypa.Runtime/Domain/Rewrite/ShellExpansion.cs
@@ -1,0 +1,13 @@
+namespace Hypa.Runtime.Domain.Rewrite;
+
+/// Detects command-substitution and variable-expansion markers (`$`, `` ` ``)
+/// embedded inside argument tokens. Such tokens must be routed through
+/// `sh -c` so the shell performs the expansion; running the program directly
+/// would pass the unexpanded text through as a literal argument.
+public static class ShellExpansion
+{
+    public static bool ContainsExpansion(IReadOnlyList<ShellToken> tokens) =>
+        tokens.Any(token =>
+            token.Kind is TokenKind.Arg or TokenKind.QuotedArg &&
+            (token.Value.Contains('$') || token.Value.Contains('`')));
+}

--- a/tests/Hypa.UnitTests/Cli/RunCommandTests.cs
+++ b/tests/Hypa.UnitTests/Cli/RunCommandTests.cs
@@ -122,6 +122,67 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public async Task BufferedDoubleQuotedVariable_UsesShellInvocation()
+    {
+        var command = "echo \"$HOME\"";
+        var (root, runner) = BuildRoot();
+        CommandInvocation? invocation = null;
+        runner.RunAsync(Arg.Do<CommandInvocation>(i => invocation = i), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("ok", "", 0, TimeSpan.Zero)));
+
+        var exitCode = await root.InvokeAsync(["-c", command]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(invocation);
+        Assert.Equal(ExpectedShell, invocation.Executable);
+        Assert.Equal(ExpectedShellArgs(command), invocation.Arguments);
+    }
+
+    [Fact]
+    public async Task BufferedCommandSubstitution_UsesShellInvocation()
+    {
+        var command = "echo \"$(date)\"";
+        var (root, runner) = BuildRoot();
+        CommandInvocation? invocation = null;
+        runner.RunAsync(Arg.Do<CommandInvocation>(i => invocation = i), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("ok", "", 0, TimeSpan.Zero)));
+
+        var exitCode = await root.InvokeAsync(["-c", command]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(invocation);
+        Assert.Equal(ExpectedShell, invocation.Executable);
+        Assert.Equal(ExpectedShellArgs(command), invocation.Arguments);
+    }
+
+    [Fact]
+    public async Task BufferedHeredocInCommandSubstitution_UsesShellInvocation()
+    {
+        var command = """
+            git commit --allow-empty -m "$(cat <<'INNER'
+            Line one
+
+            Line three
+            INNER
+            )"
+            """;
+        var (root, runner) = BuildRoot();
+        CommandInvocation? invocation = null;
+        runner.RunAsync(Arg.Do<CommandInvocation>(i => invocation = i), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("ok", "", 0, TimeSpan.Zero)));
+
+        var exitCode = await root.InvokeAsync(["-c", command]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(invocation);
+        Assert.Equal(ExpectedShell, invocation.Executable);
+        Assert.Equal(ExpectedShellArgs(command), invocation.Arguments);
+    }
+
+    [Fact]
     public async Task BufferedPlainCommand_UsesDirectInvocation()
     {
         var (root, runner) = BuildRoot();

--- a/tests/Hypa.UnitTests/Domain/ShellExpansionTests.cs
+++ b/tests/Hypa.UnitTests/Domain/ShellExpansionTests.cs
@@ -1,0 +1,59 @@
+using Hypa.Runtime.Domain.Rewrite;
+using Xunit;
+
+namespace Hypa.UnitTests.Domain;
+
+public sealed class ShellExpansionTests
+{
+    [Fact]
+    public void ContainsExpansion_QuotedDollar_ReturnsTrue()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.QuotedArg, "\"$HOME\"", 0),
+        };
+
+        var result = ShellExpansion.ContainsExpansion(tokens);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ContainsExpansion_UnquotedDollar_ReturnsTrue()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "prefix-$HOME", 0),
+        };
+
+        var result = ShellExpansion.ContainsExpansion(tokens);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ContainsExpansion_Backtick_ReturnsTrue()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "`date`", 0),
+        };
+
+        var result = ShellExpansion.ContainsExpansion(tokens);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ContainsExpansion_PlainArg_ReturnsFalse()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "plain", 0),
+        };
+
+        var result = ShellExpansion.ContainsExpansion(tokens);
+
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
## Summary

`hypa -c` silently mangled command substitutions and heredocs wrapped in a quoted argument, e.g. a multi-line `git commit -m "$(cat <<'EOF' ... EOF)"`. The literal, unexpanded heredoc text was passed through as a single argument and the commit succeeded with a garbage message — no error raised.

### Root cause
`RunCommand.HandleBufferedAsync` only routed a command through `sh -c` when a **top-level** shellism, operator, pipe, redirect, assignment prefix, or stateful builtin was detected. The shell lexer captures `"$(...)"` / `"$VAR"` inside a double-quoted string as a single `QuotedArg` token, so none of those triggers fired and the command ran directly — bypassing the shell that would perform the expansion.

### Fix
Route the command through the shell whenever any `Arg`/`QuotedArg` token value contains `$` or a backtick, via a new testable domain helper `ShellExpansion.ContainsExpansion`. Passing the whole original string to `sh -c` is semantically faithful — single-quoted literals like `'$HOME'` are still preserved by the shell exactly as before.

Fixes #44. Also fixes the closely related #42 (`$VAR` not expanded inside double quotes).

## Verification

- End-to-end: the issue's `git commit --allow-empty -m` heredoc repro now produces the expected multi-line message instead of literal heredoc text.
- `hypa -c 'echo "$HOME"'` now expands; single-quoted literals still print `$HOME` verbatim (no over-expansion).
- `dotnet build -c Release /p:TreatWarningsAsErrors=true` clean.
- `dotnet test --filter "FullyQualifiedName~RunCommandTests|FullyQualifiedName~ShellExpansion"` → 17 passed (new tests cover the double-quoted variable, command substitution, the heredoc repro, and the `ShellExpansion` helper).
- `dotnet format --verify-no-changes` clean.
