### PR TITLE
Fix pi-hypa publish version resolution for dispatched releases

### DIFF
--- a/.github/workflows/pi-package-release.yml
+++ b/.github/workflows/pi-package-release.yml
@@ -11,24 +11,28 @@ on:
         required: true
         type: string
 
-permissions:
-  actions: read
-  contents: read
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pi-package-release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  publish-pi-package:
-    name: Publish @hypabolic/pi-hypa
+  resolve-version:
+    name: Resolve release version
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
-
+    # Isolated, unprivileged job. It downloads the (untrusted) artifact produced by
+    # the upstream Release run and reduces it to a strictly-validated version string.
+    # It holds no publish credentials (no id-token: write), so a poisoned artifact
+    # cannot be leveraged to compromise the registry or repository. Only the
+    # sanitized `version` output crosses into the privileged publish job.
+    permissions:
+      actions: read     # required to download the artifact from the triggering run
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
-
       - name: Download release version
         if: ${{ github.event_name == 'workflow_run' }}
         uses: actions/download-artifact@v4
@@ -54,6 +58,20 @@ jobs:
           $version = $tag.Substring(1)
           "version=$version" >> $env:GITHUB_OUTPUT
 
+  publish-pi-package:
+    name: Publish @hypabolic/pi-hypa
+    needs: resolve-version
+    runs-on: ubuntu-latest
+    # Privileged job: holds the npm OIDC credential (id-token: write) but never
+    # touches the untrusted artifact — it only consumes the sanitized version
+    # string handed off via the resolve-version job output.
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v5
         with:
           node-version: '22'
@@ -61,7 +79,7 @@ jobs:
 
       - name: Stamp package version
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
         run: |
           set -euo pipefail
           tmp=$(mktemp)

--- a/.github/workflows/pi-package-release.yml
+++ b/.github/workflows/pi-package-release.yml
@@ -12,6 +12,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
   id-token: write
 
@@ -28,6 +29,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Download release version
+        if: ${{ github.event_name == 'workflow_run' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: release-version
+          path: release-version
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Resolve version
         id: version
         shell: pwsh
@@ -35,14 +45,11 @@ jobs:
           # Pass event data through env vars rather than ${{ }} interpolation into the
           # script body, so untrusted values can't be injected into the run step.
           INPUT_TAG: ${{ github.event.inputs.tag }}
-          RUN_TAG: ${{ github.event.workflow_run.head_branch }}
         run: |
-          # workflow_dispatch carries the tag in inputs; workflow_run runs in the
-          # default-branch context, so GITHUB_REF_NAME is 'main' — read the upstream
-          # Release run's head_branch (the pushed tag) instead.
           $tag = $env:INPUT_TAG
-          if ([string]::IsNullOrWhiteSpace($tag)) { $tag = $env:RUN_TAG }
-          if ([string]::IsNullOrWhiteSpace($tag)) { $tag = $env:GITHUB_REF_NAME }
+          if ([string]::IsNullOrWhiteSpace($tag) -and (Test-Path "release-version/release-version.txt")) {
+            $tag = (Get-Content "release-version/release-version.txt" -Raw).Trim()
+          }
           if ($tag -notmatch '^v\d+\.\d+\.\d+$') { throw "Tag must be vX.Y.Z. Got '$tag'." }
           $version = $tag.Substring(1)
           "version=$version" >> $env:GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,6 +285,16 @@ jobs:
           "tag=$tag" >> $env:GITHUB_OUTPUT
           "version=$version" >> $env:GITHUB_OUTPUT
 
+      - name: Write release version
+        run: echo "${{ steps.version.outputs.tag }}" > release-version.txt
+
+      - name: Upload release version
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-version
+          path: release-version.txt
+          if-no-files-found: error
+
       - uses: actions/setup-node@v5
         with:
           node-version: '22'
@@ -302,12 +312,12 @@ jobs:
           set -euo pipefail
           for RID in linux-x64 linux-arm64 osx-x64 osx-arm64 win-x64 win-arm64; do
             case "$RID" in
-              linux-x64)   NPM=linux-x64;    OS=linux;  CPU=x64;   EXT=tar.gz; BIN=hypa     ;;
-              linux-arm64) NPM=linux-arm64;  OS=linux;  CPU=arm64; EXT=tar.gz; BIN=hypa     ;;
-              osx-x64)     NPM=darwin-x64;   OS=darwin; CPU=x64;   EXT=tar.gz; BIN=hypa     ;;
-              osx-arm64)   NPM=darwin-arm64; OS=darwin; CPU=arm64; EXT=tar.gz; BIN=hypa     ;;
-              win-x64)     NPM=win32-x64;    OS=win32;  CPU=x64;   EXT=zip;    BIN=hypa.exe ;;
-              win-arm64)   NPM=win32-arm64;  OS=win32;  CPU=arm64; EXT=zip;    BIN=hypa.exe ;;
+              linux-x64)   NPM=linux-x64;    OS=linux;  CPU=x64;   EXT=tar.gz ;;
+              linux-arm64) NPM=linux-arm64;  OS=linux;  CPU=arm64; EXT=tar.gz ;;
+              osx-x64)     NPM=darwin-x64;   OS=darwin; CPU=x64;   EXT=tar.gz ;;
+              osx-arm64)   NPM=darwin-arm64; OS=darwin; CPU=arm64; EXT=tar.gz ;;
+              win-x64)     NPM=win32-x64;    OS=win32;  CPU=x64;   EXT=zip    ;;
+              win-arm64)   NPM=win32-arm64;  OS=win32;  CPU=arm64; EXT=zip    ;;
             esac
 
             STAGE="staging/hypa-${NPM}"
@@ -441,10 +451,12 @@ jobs:
         id: sha
         run: |
           extract() { grep " $1" dist/SHA256SUMS | awk '{print $1}'; }
-          echo "linux_x64=$(extract hypa-linux-x64.tar.gz)"    >> $GITHUB_OUTPUT
-          echo "linux_arm64=$(extract hypa-linux-arm64.tar.gz)" >> $GITHUB_OUTPUT
-          echo "osx_x64=$(extract hypa-osx-x64.tar.gz)"        >> $GITHUB_OUTPUT
-          echo "osx_arm64=$(extract hypa-osx-arm64.tar.gz)"    >> $GITHUB_OUTPUT
+          {
+            echo "linux_x64=$(extract hypa-linux-x64.tar.gz)"
+            echo "linux_arm64=$(extract hypa-linux-arm64.tar.gz)"
+            echo "osx_x64=$(extract hypa-osx-x64.tar.gz)"
+            echo "osx_arm64=$(extract hypa-osx-arm64.tar.gz)"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate formula
         env:


### PR DESCRIPTION
## Summary

`pi install npm:@hypabolic/pi-hypa` installed the old 0.1.6 because **pi-hypa 0.1.7 was never published** — npm `latest` for `@hypabolic/pi-hypa` is stuck at 0.1.6 while `@hypabolic/hypa` reached 0.1.7.

## Root cause

The **Publish Pi Package** workflow (`pi-package-release.yml`) runs on `workflow_run` after **Release** completes and derived the version from `github.event.workflow_run.head_branch`. For v0.1.7 the tag-push Release failed, so Release was re-run via `workflow_dispatch` (which correctly published `@hypabolic/hypa` 0.1.7). But a dispatched Release run has `head_branch = main`, and `inputs.tag` is empty for `workflow_run` events, so the "Resolve version" step threw:

```
Tag must be vX.Y.Z. Got 'main'.
```

and pi-hypa was never published. (Confirmed in the failed run 28489569127.)

## Fix — deterministic version hand-off

- `release.yml` (`publish-npm` job): upload the already-resolved tag as a `release-version` artifact.
- `pi-package-release.yml`:
  - Add `actions: read` (required for `actions/download-artifact@v4` cross-run download).
  - For `workflow_run` events, download `release-version` from `github.event.workflow_run.id`.
  - Resolve the version from `inputs.tag` first, then the artifact; drop the fragile `head_branch`/`GITHUB_REF_NAME` guessing.

This makes both tag-push and `workflow_dispatch` releases publish pi-hypa with the correct version.

Also groups `$GITHUB_OUTPUT` writes and removes an unused shell variable in `release.yml` so `actionlint` passes on the edited files.

## Verification

- `actionlint` passes on the edited workflows and across the whole repo (no regressions).
- Logic traced for all trigger paths: tag-push Release, dispatched Release, and manual dispatch of Publish Pi Package.

## Follow-up (operational, not in this PR)

pi-hypa 0.1.7 still needs to be published so users get the latest. Once this merges, that can be done by manually dispatching **Publish Pi Package** with `tag=v0.1.7` (the manual-dispatch path already resolves the version from `inputs.tag`).

Fixes #41.
