### PR TITLE
Fix pi-hypa config path resolution when HYPA_PI_CONFIG is unset

### DIFF
--- a/packages/pi-hypa/extensions/policy.ts
+++ b/packages/pi-hypa/extensions/policy.ts
@@ -26,8 +26,10 @@ export function parseBooleanFlag(value: string | undefined): boolean {
 
 export function resolveConfigFilePath(env: NodeJS.ProcessEnv): string | undefined {
   const fromEnv = env.HYPA_PI_CONFIG?.trim();
-  if (fromEnv === "" || fromEnv.toLowerCase() === "none") return undefined;
-  if (fromEnv) return fromEnv;
+  if (fromEnv !== undefined) {
+    if (fromEnv === "" || fromEnv.toLowerCase() === "none") return undefined;
+    return fromEnv;
+  }
   return path.join(os.homedir(), ".hypa-pi", "config.json");
 }
 

--- a/packages/pi-hypa/test/policy.test.ts
+++ b/packages/pi-hypa/test/policy.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import test from "node:test";
 import { after } from "node:test";
 import assert from "node:assert/strict";
-import { isHypaCommand, loadConfig, loadConfigFile, mapRewriteResult, parseRewriteJson } from "../extensions/policy.js";
+import { isHypaCommand, loadConfig, loadConfigFile, mapRewriteResult, parseRewriteJson, resolveConfigFilePath } from "../extensions/policy.js";
 
 const tempRoot = mkdtempSync(join(tmpdir(), "pi-hypa-policy-"));
 
@@ -148,4 +148,19 @@ test("loadConfig treats HYPA_PI_CONFIG=none and NONE and None as disable", () =>
     const config = loadConfig({ HYPA_PI_CONFIG: sentinel });
     assert.equal(config.mode, "additive", `sentinel "${sentinel}" should disable config file`);
   }
+});
+
+test("resolveConfigFilePath defaults to the home config path when HYPA_PI_CONFIG is unset", () => {
+  const resolved = resolveConfigFilePath({});
+  assert.ok(resolved && resolved.endsWith(join(".hypa-pi", "config.json")));
+});
+
+test("resolveConfigFilePath returns undefined for empty or 'none' values", () => {
+  assert.equal(resolveConfigFilePath({ HYPA_PI_CONFIG: "" }), undefined);
+  assert.equal(resolveConfigFilePath({ HYPA_PI_CONFIG: "  " }), undefined);
+  assert.equal(resolveConfigFilePath({ HYPA_PI_CONFIG: "NONE" }), undefined);
+});
+
+test("resolveConfigFilePath returns an explicit trimmed path", () => {
+  assert.equal(resolveConfigFilePath({ HYPA_PI_CONFIG: "  /tmp/custom.json  " }), "/tmp/custom.json");
 });


### PR DESCRIPTION
## Summary

The pi-package publish (`Validate package` → `npm run build`) fails on a pre-existing TypeScript error, blocking the release of `@hypabolic/pi-hypa` (currently stuck at 0.1.6):

```
extensions/policy.ts(29,25): error TS18048: 'fromEnv' is possibly 'undefined'.
```

`resolveConfigFilePath` dereferenced the optional `HYPA_PI_CONFIG` value (`fromEnv.toLowerCase()`) before checking for `undefined`. Besides the compile error, this is a latent runtime crash whenever `HYPA_PI_CONFIG` is unset.

## Fix

Guard for `undefined` first, then handle the empty/`none` disable sentinels and an explicit path. Behavior is unchanged for all defined values.

## Verification

- `npm run build` (`tsc --noEmit`) clean.
- `npm test` → 46 passed (added 3 regression tests for `resolveConfigFilePath`: unset → default home path, empty/`none` → undefined, explicit path passthrough).
