### PR TITLE
Fix pi-hypa extension tools failing on Windows with spawn EFTYPE

### DIFF
--- a/packages/pi-hypa/extensions/index.ts
+++ b/packages/pi-hypa/extensions/index.ts
@@ -34,7 +34,7 @@ export default function (pi: ExtensionAPI) {
   }
 
   registerHypaTools(hypaPi, effectiveConfig);
-  registerHypaMcpProxyBridge(hypaPi, config);
+  registerHypaMcpProxyBridge(hypaPi, effectiveConfig);
 
   if (config.mode === "replace") {
     pi.on("before_agent_start", () => {

--- a/packages/pi-hypa/extensions/rewrite-client.ts
+++ b/packages/pi-hypa/extensions/rewrite-client.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { delimiter, dirname, join, resolve, win32 } from "node:path";
+import { dirname, join, posix, win32 } from "node:path";
 import { platform } from "node:os";
 import { createRequire } from "node:module";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -56,8 +56,8 @@ function resolvePathBinary(
   if (!path) return undefined;
 
   const isWindows = platformName === "win32";
-  const pathDelimiter = isWindows ? ";" : delimiter;
-  const resolvePath = isWindows ? win32.resolve : resolve;
+  const pathDelimiter = isWindows ? ";" : ":";
+  const resolvePath = isWindows ? win32.resolve : posix.resolve;
   const executableExtensions = isWindows ? getWindowsExecutableExtensions(env) : [];
   const binaryLower = binary.toLowerCase();
   const hasExecutableExtension =

--- a/packages/pi-hypa/extensions/rewrite-client.ts
+++ b/packages/pi-hypa/extensions/rewrite-client.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { delimiter, dirname, join, resolve } from "node:path";
+import { delimiter, dirname, join, resolve, win32 } from "node:path";
 import { platform } from "node:os";
 import { createRequire } from "node:module";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -29,42 +29,96 @@ export function getExecArgs(
 
 const require = createRequire(import.meta.url);
 
-export function resolveHypaBinary(binary: string, env: NodeJS.ProcessEnv = process.env): string {
+export function resolveHypaBinary(
+  binary: string,
+  env: NodeJS.ProcessEnv = process.env,
+  platformName: string = platform(),
+  exists: (p: string) => boolean = existsSync,
+): string {
   if (binary.includes("/") || binary.includes("\\")) return binary;
 
-  const pathBinary = resolvePathBinary(binary, env);
+  const pathBinary = resolvePathBinary(binary, env, platformName, exists);
   if (pathBinary) return pathBinary;
 
-  const bundledBinary = resolveBundledHypaBinary(binary);
+  const bundledBinary = resolveBundledHypaBinary(binary, exists);
   if (bundledBinary) return bundledBinary;
 
   return binary;
 }
 
-function resolvePathBinary(binary: string, env: NodeJS.ProcessEnv): string | undefined {
+function resolvePathBinary(
+  binary: string,
+  env: NodeJS.ProcessEnv,
+  platformName: string,
+  exists: (p: string) => boolean,
+): string | undefined {
   const path = env.PATH;
   if (!path) return undefined;
 
-  const isWindows = platform() === "win32";
-  for (const dir of path.split(delimiter)) {
+  const isWindows = platformName === "win32";
+  const pathDelimiter = isWindows ? ";" : delimiter;
+  const resolvePath = isWindows ? win32.resolve : resolve;
+  const executableExtensions = isWindows ? getWindowsExecutableExtensions(env) : [];
+  const binaryLower = binary.toLowerCase();
+  const hasExecutableExtension =
+    isWindows && executableExtensions.some((extension) => binaryLower.endsWith(extension.toLowerCase()));
+
+  for (const dir of path.split(pathDelimiter)) {
     if (!dir) continue;
-    const candidate = resolve(dir, binary);
-    if (existsSync(candidate)) return candidate;
-    if (isWindows && existsSync(`${candidate}.exe`)) return `${candidate}.exe`;
-    if (isWindows && existsSync(`${candidate}.cmd`)) return `${candidate}.cmd`;
+    const candidate = resolvePath(dir, binary);
+
+    if (!isWindows) {
+      if (exists(candidate)) return candidate;
+      continue;
+    }
+
+    if (hasExecutableExtension) {
+      if (exists(candidate)) return candidate;
+      continue;
+    }
+
+    for (const extension of executableExtensions) {
+      const executableCandidate = `${candidate}${extension}`;
+      if (exists(executableCandidate)) return executableCandidate;
+    }
   }
 
   return undefined;
 }
 
-function resolveBundledHypaBinary(binary: string): string | undefined {
+function getWindowsExecutableExtensions(env: NodeJS.ProcessEnv): string[] {
+  const rawExtensions = env.PATHEXT?.trim() ? env.PATHEXT : ".COM;.EXE;.BAT;.CMD";
+  const extensions: string[] = [];
+  const seen = new Set<string>();
+
+  for (const extension of rawExtensions.split(";")) {
+    const trimmed = extension.trim();
+    if (!trimmed) continue;
+    const normalized = trimmed.startsWith(".") ? trimmed : `.${trimmed}`;
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    extensions.push(normalized);
+  }
+
+  for (const extension of [".exe", ".cmd"]) {
+    const key = extension.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    extensions.push(extension);
+  }
+
+  return extensions;
+}
+
+function resolveBundledHypaBinary(binary: string, exists: (p: string) => boolean): string | undefined {
   if (binary !== "hypa") return undefined;
 
   try {
     const packageJson = require.resolve("@hypabolic/hypa/package.json");
     const packageRoot = dirname(packageJson);
     const bin = join(packageRoot, "bin.js");
-    return existsSync(bin) ? bin : undefined;
+    return exists(bin) ? bin : undefined;
   } catch {
     return undefined;
   }

--- a/packages/pi-hypa/test/rewrite-client.test.ts
+++ b/packages/pi-hypa/test/rewrite-client.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { win32 } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { resolveHypaBinary, rewriteCommand, getExecArgs } from "../extensions/rewrite-client.js";
 import type { HypaPiConfig } from "../extensions/types.js";
@@ -24,9 +25,77 @@ function fakePi(stdout: string, overrides: Partial<{ code: number; stderr: strin
   } as unknown as ExtensionAPI;
 }
 
+function fakeExists(paths: string[]) {
+  const existing = new Set(paths.map((path) => path.toLowerCase()));
+  return (path: string) => existing.has(path.toLowerCase());
+}
+
 test("resolveHypaBinary falls back to bundled dependency when PATH is empty", () => {
   const resolved = resolveHypaBinary("hypa", { PATH: "" });
   assert.match(resolved, /@hypabolic\/hypa|node_modules\/\.pnpm\/.*@hypabolic\+hypa/);
+});
+
+test("resolveHypaBinary prefers Windows .cmd over extension-less npm shim", () => {
+  const binDir = "C:\\Users\\test\\AppData\\Roaming\\npm";
+  const shim = win32.resolve(binDir, "hypa");
+  const cmd = win32.resolve(binDir, "hypa.cmd");
+
+  const resolved = resolveHypaBinary("hypa", { PATH: binDir }, "win32", fakeExists([shim, cmd]));
+
+  assert.equal(resolved.toLowerCase(), cmd.toLowerCase());
+  assert.notEqual(resolved.toLowerCase(), shim.toLowerCase());
+});
+
+test("resolveHypaBinary prefers Windows .exe over .cmd in the same PATH directory", () => {
+  const binDir = "C:\\hypa-bin";
+  const exe = win32.resolve(binDir, "hypa.exe");
+  const cmd = win32.resolve(binDir, "hypa.cmd");
+
+  const resolved = resolveHypaBinary("hypa", { PATH: binDir }, "win32", fakeExists([exe, cmd]));
+
+  assert.equal(resolved.toLowerCase(), exe.toLowerCase());
+});
+
+test("resolveHypaBinary does not return extension-less Windows shim without executable extension match", () => {
+  const binDir = "C:\\hypa-bin";
+  const shim = win32.resolve(binDir, "hypa");
+
+  const resolved = resolveHypaBinary("hypa", { PATH: binDir }, "win32", fakeExists([shim]));
+
+  assert.notEqual(resolved.toLowerCase(), shim.toLowerCase());
+});
+
+test("resolveHypaBinary returns explicit Windows .exe binary when it exists on PATH", () => {
+  const binDir = "C:\\hypa-bin";
+  const exe = win32.resolve(binDir, "hypa.exe");
+
+  const resolved = resolveHypaBinary("hypa.exe", { PATH: binDir }, "win32", fakeExists([exe]));
+
+  assert.equal(resolved.toLowerCase(), exe.toLowerCase());
+});
+
+test("resolveHypaBinary returns extension-less binary on non-Windows PATH", () => {
+  const binDir = "/usr/local/bin";
+  const shim = "/usr/local/bin/hypa";
+
+  const resolved = resolveHypaBinary("hypa", { PATH: binDir }, "linux", fakeExists([shim]));
+
+  assert.equal(resolved, shim);
+});
+
+test("resolveHypaBinary honours Windows PATHEXT priority case-insensitively", () => {
+  const binDir = "C:\\hypa-bin";
+  const foo = win32.resolve(binDir, "hypa.foo");
+  const cmd = win32.resolve(binDir, "hypa.cmd");
+
+  const resolved = resolveHypaBinary(
+    "hypa",
+    { PATH: binDir, PATHEXT: ".FOO;.CMD" },
+    "win32",
+    fakeExists([foo, cmd]),
+  );
+
+  assert.equal(resolved.toLowerCase(), foo.toLowerCase());
 });
 
 test("rewriteCommand skips commands already starting with hypa", async () => {


### PR DESCRIPTION
## Summary

Fixes #40 — on Windows, all Pi Hypa extension tools (`hypa_ls`, `hypa_find`, `hypa_grep`, `hypa_read`, `hypa_shell`) failed with `spawn EFTYPE` even though the `hypa` CLI worked fine from the shell.

## Root cause

On Windows, npm installs **three** files into its global bin dir: an extension-less POSIX shell shim `hypa` (not natively executable on Windows), plus `hypa.cmd` and `hypa.ps1`. In `rewrite-client.ts`, `resolvePathBinary` checked the bare extension-less candidate **first**, so it returned `...\npm\hypa`. `getExecArgs` doesn't recognise an extension-less path, passed it raw to `pi.exec`, and Node's `spawn` of an extension-less shell script produced `spawn EFTYPE`. The known `HYPA_BIN`→`.exe` workaround succeeded precisely because an absolute `.exe` path bypasses this resolution.

A secondary bug: `index.ts` registered the MCP proxy bridge with the **unresolved** `config`, so that path spawned the bare `"hypa"` name too.

## Fix

- **`rewrite-client.ts`** — On Windows, resolve PATH entries using `PATHEXT` priority order (always unioning in `.exe`/`.cmd`), and **never** return the extension-less POSIX shim. If the requested name already carries an executable extension, it's matched directly. Non-Windows behaviour is unchanged. Resolution is now made deterministic/testable via injectable `platformName` + `exists` parameters (defaults preserve existing call sites).
- **`index.ts`** — Register the MCP proxy bridge with `effectiveConfig` (resolved binary), matching the tools path.

`getExecArgs` was already correct (`.cmd`/`.bat`→`cmd /c`, `.js`→`node`, `.exe` passthrough), so a resolved `.exe`/`.cmd`/bundled `bin.js` now spawns correctly.

## Verification

- `npm run build` (`tsc --noEmit`) clean.
- `npm test` → **52 passed** (added 6 Windows resolution regression tests: `.cmd` preferred over the shim, `.exe` preferred over `.cmd`, extension-less shim never returned, explicit `.exe` name honoured, non-Windows extension-less preserved, `PATHEXT` priority honoured case-insensitively).
