### PR TITLE
Fix VS Code Copilot hook to match run_in_terminal tool

### DIFF
--- a/src/Hypa.Infrastructure/Hooks/Adapters/CopilotVscodeAdapter.cs
+++ b/src/Hypa.Infrastructure/Hooks/Adapters/CopilotVscodeAdapter.cs
@@ -15,7 +15,7 @@ public sealed class CopilotVscodeAdapter : IAgentHarnessAdapter
             return null;
 
         var toolName = toolNameEl.GetString();
-        if (toolName != "runTerminalCommand")
+        if (toolName != "run_in_terminal")
             return null;
 
         if (!json.TryGetProperty("tool_input", out var toolInput))

--- a/tests/Hypa.UnitTests/Infrastructure/Hooks/CopilotVscodeAdapterTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Hooks/CopilotVscodeAdapterTests.cs
@@ -10,9 +10,9 @@ public sealed class CopilotVscodeAdapterTests
     private readonly CopilotVscodeAdapter _adapter = new();
 
     [Fact]
-    public void Parse_RunTerminalCommand_ReturnsInput()
+    public void Parse_RunInTerminal_ReturnsInput()
     {
-        var json = ParseJson("""{"tool_name":"runTerminalCommand","tool_input":{"command":"git status"}}""");
+        var json = ParseJson("""{"tool_name":"run_in_terminal","tool_input":{"command":"git status"}}""");
         var result = _adapter.Parse(json);
         Assert.NotNull(result);
         Assert.Equal("git status", result.Command);
@@ -22,6 +22,13 @@ public sealed class CopilotVscodeAdapterTests
     public void Parse_NonTerminalTool_ReturnsNull()
     {
         var json = ParseJson("""{"tool_name":"Bash","tool_input":{"command":"git status"}}""");
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_LegacyRunTerminalCommand_ReturnsNull()
+    {
+        var json = ParseJson("""{"tool_name":"runTerminalCommand","tool_input":{"command":"git status"}}""");
         Assert.Null(_adapter.Parse(json));
     }
 
@@ -54,5 +61,5 @@ public sealed class CopilotVscodeAdapterTests
         JsonDocument.Parse(json).RootElement;
 
     private static AgentHookInput MakeInput(string command) =>
-        new("runTerminalCommand", command, ParseJson($$$"""{"tool_name":"runTerminalCommand","tool_input":{"command":"{{{command}}}"}}"""));
+        new("run_in_terminal", command, ParseJson($$$"""{"tool_name":"run_in_terminal","tool_input":{"command":"{{{command}}}"}}"""));
 }


### PR DESCRIPTION
## Summary

Fixes #39 — Hypa's PreToolUse hook never fired for VS Code Copilot because the adapter matched the wrong terminal tool name.

`CopilotVscodeAdapter.Parse` rejected anything that wasn't `"runTerminalCommand"`, but VS Code Copilot never emits that name. The real tool name (confirmed by the reporter's `PostToolUse` debug log) is **`run_in_terminal`**, so every genuine terminal command was ignored and no command rewriting occurred in VS Code.

## Fix

- `CopilotVscodeAdapter.cs` — accept `"run_in_terminal"` instead of `"runTerminalCommand"`.
- Tests — updated the parse test + `MakeInput` helper to the correct name, renamed `Parse_RunTerminalCommand_ReturnsInput` → `Parse_RunInTerminal_ReturnsInput`, and added `Parse_LegacyRunTerminalCommand_ReturnsNull` as a regression guard.

## Verification

- `dotnet test ... --filter FullyQualifiedName~CopilotVscodeAdapterTests` → **6 passed, 0 failed**.
- `dotnet format --verify-no-changes` clean on the touched files.
