### PR TITLE
Rewrite commands in the Copilot CLI hook via modifiedArgs

### DIFF
--- a/src/Hypa.Infrastructure/Hooks/Adapters/CopilotCliAdapter.cs
+++ b/src/Hypa.Infrastructure/Hooks/Adapters/CopilotCliAdapter.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Hypa.Runtime.Application.Ports;
 using Hypa.Runtime.Domain.Hooks;
 
@@ -35,7 +36,9 @@ public sealed class CopilotCliAdapter : IAgentHarnessAdapter
             if (command is null)
                 return null;
 
-            return new AgentHookInput(toolName, command, json);
+            // Normalise to the canonical "Bash" tool name so HookService's shell
+            // gate fires (Copilot CLI reports the shell tool as lowercase "bash").
+            return new AgentHookInput("Bash", command, json);
         }
         catch (JsonException)
         {
@@ -47,9 +50,9 @@ public sealed class CopilotCliAdapter : IAgentHarnessAdapter
     {
         return decision switch
         {
-            HookDecision.Rewrite r => FormatDenyWithSuggestion($"Use: {r.Command}"),
-            HookDecision.Deny d => FormatDenyWithSuggestion(d.Reason),
-            HookDecision.Ask a => FormatDenyWithSuggestion(a.Reason),
+            HookDecision.Rewrite r => FormatModifiedArgs(r.Command),
+            HookDecision.Deny d => FormatPermission("deny", d.Reason),
+            HookDecision.Ask a => FormatPermission("ask", a.Reason),
             _ => new AgentHookOutput(0, null),
         };
     }
@@ -72,9 +75,16 @@ public sealed class CopilotCliAdapter : IAgentHarnessAdapter
         ]);
     }
 
-    private static AgentHookOutput FormatDenyWithSuggestion(string reason)
+    private static AgentHookOutput FormatModifiedArgs(string command)
     {
-        var output = new CopilotCliOutput("deny", reason);
+        var output = new CopilotCliOutput(null, null, new CopilotCliModifiedArgs(command));
+        var json = JsonSerializer.Serialize(output, HooksJsonContext.Default.CopilotCliOutput);
+        return new AgentHookOutput(0, json);
+    }
+
+    private static AgentHookOutput FormatPermission(string decision, string reason)
+    {
+        var output = new CopilotCliOutput(decision, reason, null);
         var json = JsonSerializer.Serialize(output, HooksJsonContext.Default.CopilotCliOutput);
         return new AgentHookOutput(0, json);
     }
@@ -82,5 +92,8 @@ public sealed class CopilotCliAdapter : IAgentHarnessAdapter
 }
 
 internal sealed record CopilotCliOutput(
-    string PermissionDecision,
-    string PermissionDecisionReason);
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? PermissionDecision,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? PermissionDecisionReason,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] CopilotCliModifiedArgs? ModifiedArgs);
+
+internal sealed record CopilotCliModifiedArgs(string Command);

--- a/src/Hypa.Infrastructure/Hooks/Adapters/CopilotVscodeAdapter.cs
+++ b/src/Hypa.Infrastructure/Hooks/Adapters/CopilotVscodeAdapter.cs
@@ -28,7 +28,9 @@ public sealed class CopilotVscodeAdapter : IAgentHarnessAdapter
         if (command is null)
             return null;
 
-        return new AgentHookInput(toolName, command, json);
+        // Normalise to the canonical "Bash" tool name so HookService's shell gate
+        // fires (Copilot in VS Code reports the shell tool as "run_in_terminal").
+        return new AgentHookInput("Bash", command, json);
     }
 
     public AgentHookOutput Format(HookDecision decision, AgentHookInput input)

--- a/src/Hypa.Infrastructure/Hooks/HooksJsonContext.cs
+++ b/src/Hypa.Infrastructure/Hooks/HooksJsonContext.cs
@@ -10,6 +10,7 @@ namespace Hypa.Infrastructure.Hooks;
 [JsonSerializable(typeof(ClaudeRedirectInput))]
 [JsonSerializable(typeof(ClaudeRedirectPath))]
 [JsonSerializable(typeof(CopilotCliOutput))]
+[JsonSerializable(typeof(CopilotCliModifiedArgs))]
 [JsonSerializable(typeof(CodexHookOutput))]
 [JsonSerializable(typeof(CodexHookSpecificOutput))]
 internal sealed partial class HooksJsonContext : JsonSerializerContext { }

--- a/tests/Hypa.UnitTests/Infrastructure/Hooks/CopilotCliAdapterTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Hooks/CopilotCliAdapterTests.cs
@@ -16,6 +16,7 @@ public sealed class CopilotCliAdapterTests
         var result = _adapter.Parse(json);
         Assert.NotNull(result);
         Assert.Equal("git status", result.Command);
+        Assert.Equal("Bash", result.ToolName);
     }
 
     [Fact]
@@ -33,15 +34,18 @@ public sealed class CopilotCliAdapterTests
     }
 
     [Fact]
-    public void Format_Rewrite_EmitsDenyWithSuggestion()
+    public void Format_Rewrite_EmitsModifiedArgs()
     {
         var input = MakeInput("git status");
-        var decision = new HookDecision.Rewrite("hypa git status");
+        var decision = new HookDecision.Rewrite("hypa -c \"git status\"");
         var output = _adapter.Format(decision, input);
         Assert.Equal(0, output.ExitCode);
         Assert.NotNull(output.JsonBody);
-        Assert.Contains("deny", output.JsonBody);
-        Assert.Contains("Use: hypa git status", output.JsonBody);
+        Assert.Contains("modifiedArgs", output.JsonBody);
+        Assert.Contains("command", output.JsonBody);
+        Assert.Contains(@"hypa -c \u0022git status\u0022", output.JsonBody);
+        Assert.DoesNotContain("permissionDecision", output.JsonBody);
+        Assert.DoesNotContain("deny", output.JsonBody);
     }
 
     [Fact]
@@ -53,6 +57,18 @@ public sealed class CopilotCliAdapterTests
         Assert.NotNull(output.JsonBody);
         Assert.Contains("deny", output.JsonBody);
         Assert.Contains("Command blocked", output.JsonBody);
+    }
+
+    [Fact]
+    public void Format_Ask_EmitsAskWithReason()
+    {
+        var input = MakeInput("git push");
+        var decision = new HookDecision.Ask("Confirm?");
+        var output = _adapter.Format(decision, input);
+        Assert.NotNull(output.JsonBody);
+        Assert.Contains("ask", output.JsonBody);
+        Assert.Contains("Confirm?", output.JsonBody);
+        Assert.DoesNotContain("deny", output.JsonBody);
     }
 
     [Fact]

--- a/tests/Hypa.UnitTests/Infrastructure/Hooks/CopilotVscodeAdapterTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Hooks/CopilotVscodeAdapterTests.cs
@@ -16,6 +16,7 @@ public sealed class CopilotVscodeAdapterTests
         var result = _adapter.Parse(json);
         Assert.NotNull(result);
         Assert.Equal("git status", result.Command);
+        Assert.Equal("Bash", result.ToolName);
     }
 
     [Fact]


### PR DESCRIPTION
## What & why

`hypa hook --agent copilot-cli` returned rewrite decisions as a deny-with-suggestion
(`{"permissionDecision":"deny","permissionDecisionReason":"Use: ..."}`), which the
GitHub Copilot CLI surfaces as a rejection rather than applying Hypa's rewritten
command. Copilot CLI only rewrites a tool call when the hook emits a `modifiedArgs`
object.

This PR makes the Copilot CLI `preToolUse` hook actually rewrite commands:

- **Emit `modifiedArgs`** for rewrite decisions (`{"modifiedArgs":{"command":"..."}}`),
  matching the Copilot SDK `PreToolUseHookOutput` schema. Deny/ask now map to native
  `permissionDecision` values (`deny`/`ask`) with a reason.
- **Normalise the tool name to `Bash`.** `HookService.ProcessAsync` only runs the
  rewrite pipeline when `ToolName == "Bash"`. The Copilot CLI adapter passed the raw
  lowercase `bash`, so *every* command silently passed through and the hook emitted
  nothing. `CodexAdapter` already normalises; this brings the Copilot CLI adapter in line.

## Also completes the end-to-end fix for #39

The VS Code Copilot adapter had the identical gap: after #39 matched the
`run_in_terminal` tool name, `Parse` still returned it un-normalised, so the shell
gate dropped it and the VS Code hook never fired end-to-end. Normalising it to `Bash`
here makes that hook emit output too.

## Verification

- `dotnet build` (Debug) clean; `dotnet format --verify-no-changes` clean.
- Full Hooks unit suite: 222 passed.
- End-to-end:
  - `copilot-cli` + `dotnet build` → `{"modifiedArgs":{"command":"hypa dotnet build"}}`
  - `copilot-vscode` + `dotnet build` → `{"updatedInput":{"command":"hypa dotnet build"}}`

Closes #38
