### PR TITLE
Fix Copilot CLI hook auto-detection for PascalCase and powershell payloads

### DIFF
--- a/src/Hypa.Infrastructure/Hooks/Adapters/ClaudeCodeAdapter.cs
+++ b/src/Hypa.Infrastructure/Hooks/Adapters/ClaudeCodeAdapter.cs
@@ -15,6 +15,11 @@ public sealed class ClaudeCodeAdapter(ISkillRenderer skillRenderer) : IAgentHarn
         if (!json.TryGetProperty("hook_event_name", out _))
             return null;
 
+        // Copilot CLI PascalCase PreToolUse reuses hook_event_name/tool_name/tool_input
+        // but omits Claude-only fields. Refuse those so CopilotCliAdapter can claim them.
+        if (!ClaudePayloadMarkers.HasClaudeMarker(json))
+            return null;
+
         if (!json.TryGetProperty("tool_name", out var toolNameEl))
             return null;
 
@@ -27,7 +32,7 @@ public sealed class ClaudeCodeAdapter(ISkillRenderer skillRenderer) : IAgentHarn
             if (!toolInput.TryGetProperty("command", out var commandEl))
                 return null;
             var command = commandEl.GetString();
-            if (command is null)
+            if (string.IsNullOrEmpty(command))
                 return null;
             return new AgentHookInput(toolName, command, json);
         }

--- a/src/Hypa.Infrastructure/Hooks/Adapters/ClaudePayloadMarkers.cs
+++ b/src/Hypa.Infrastructure/Hooks/Adapters/ClaudePayloadMarkers.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+
+namespace Hypa.Infrastructure.Hooks.Adapters;
+
+/// <summary>
+/// Fields that appear on real Claude Code hook envelopes but not on Copilot CLI
+/// PascalCase PreToolUse payloads that reuse hook_event_name/tool_name/tool_input.
+/// </summary>
+internal static class ClaudePayloadMarkers
+{
+    public static bool HasClaudeMarker(JsonElement json) =>
+        IsNonEmptyStringProperty(json, "transcript_path") ||
+        IsNonEmptyStringProperty(json, "permission_mode") ||
+        IsNonEmptyStringProperty(json, "tool_use_id");
+
+    private static bool IsNonEmptyStringProperty(JsonElement json, string name) =>
+        json.TryGetProperty(name, out var el) &&
+        el.ValueKind == JsonValueKind.String &&
+        !string.IsNullOrEmpty(el.GetString());
+}

--- a/src/Hypa.Infrastructure/Hooks/Adapters/CopilotCliAdapter.cs
+++ b/src/Hypa.Infrastructure/Hooks/Adapters/CopilotCliAdapter.cs
@@ -138,6 +138,11 @@ public sealed class CopilotCliAdapter : IAgentHarnessAdapter
     private static bool TryGetCommand(JsonElement argsRoot, out string command)
     {
         command = "";
+        // toolArgs as a JSON *string* may parse to a non-object root (e.g. "42", "null", "[]").
+        // TryGetProperty throws InvalidOperationException on non-objects — not caught as JsonException.
+        if (argsRoot.ValueKind != JsonValueKind.Object)
+            return false;
+
         if (!argsRoot.TryGetProperty("command", out var commandEl) ||
             commandEl.ValueKind != JsonValueKind.String)
             return false;

--- a/src/Hypa.Infrastructure/Hooks/Adapters/CopilotCliAdapter.cs
+++ b/src/Hypa.Infrastructure/Hooks/Adapters/CopilotCliAdapter.cs
@@ -7,43 +7,73 @@ namespace Hypa.Infrastructure.Hooks.Adapters;
 
 public sealed class CopilotCliAdapter : IAgentHarnessAdapter
 {
+    // Only Copilot-documented shell runtimes (bash/powershell) and the Claude-mapped
+    // PreToolUse name "Bash" (matched via OrdinalIgnoreCase — do NOT copy Codex's
+    // broader set: Shell, command, exec_command, functions.exec_command, etc.).
+    // Omitted on purpose: pwsh, cmd, and any non-shell tool (view, edit, …).
+    private static readonly HashSet<string> ShellToolNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "bash",
+        "powershell",
+    };
+
     public string Key => "copilot-cli";
     public HarnessCapability Capability => HarnessCapability.PreToolUse;
 
     public AgentHookInput? Parse(JsonElement json)
     {
-        if (!json.TryGetProperty("toolName", out var toolNameEl))
+        if (json.ValueKind != JsonValueKind.Object)
             return null;
 
-        var toolName = toolNameEl.GetString();
-        if (toolName != "bash")
-            return null;
-
-        if (!json.TryGetProperty("toolArgs", out var toolArgsEl))
-            return null;
-
-        var toolArgsJson = toolArgsEl.GetString();
-        if (toolArgsJson is null)
-            return null;
-
-        try
+        // --- Native camelCase (preToolUse) ---
+        // No event-name gate: native payloads often omit an event field; the host
+        // only invokes this hook for the registered preToolUse event (symmetric to
+        // the PascalCase branch which checks hook_event_name == "PreToolUse").
+        if (json.TryGetProperty("toolName", out var toolNameEl) &&
+            toolNameEl.ValueKind == JsonValueKind.String)
         {
-            using var argsDoc = JsonDocument.Parse(toolArgsJson);
-            if (!argsDoc.RootElement.TryGetProperty("command", out var commandEl))
+            var toolName = toolNameEl.GetString();
+            if (toolName is null || !ShellToolNames.Contains(toolName))
                 return null;
 
-            var command = commandEl.GetString();
-            if (command is null)
+            if (!TryExtractCommandFromToolArgs(json, out var command))
                 return null;
 
             // Normalise to the canonical "Bash" tool name so HookService's shell
-            // gate fires (Copilot CLI reports the shell tool as lowercase "bash").
+            // gate fires (Copilot CLI reports the shell tool as lowercase "bash"
+            // or "powershell").
             return new AgentHookInput("Bash", command, json);
         }
-        catch (JsonException)
-        {
+
+        // --- PascalCase / VS Code-compatible (PreToolUse) ---
+        // Require the PreToolUse event name (case-sensitive per Copilot docs).
+        // Pre-existing Claude adapter only checked presence of hook_event_name;
+        // validating the value here is free safety so PostToolUse shells are not rewritten.
+        if (!json.TryGetProperty("hook_event_name", out var eventEl) ||
+            eventEl.ValueKind != JsonValueKind.String ||
+            !string.Equals(eventEl.GetString(), "PreToolUse", StringComparison.Ordinal))
             return null;
-        }
+
+        // Real Claude payloads must not be claimed here (mutual refusal with ClaudeCodeAdapter).
+        if (ClaudePayloadMarkers.HasClaudeMarker(json))
+            return null;
+
+        if (!json.TryGetProperty("tool_name", out var snakeToolEl) ||
+            snakeToolEl.ValueKind != JsonValueKind.String)
+            return null;
+
+        var snakeTool = snakeToolEl.GetString();
+        if (snakeTool is null || !ShellToolNames.Contains(snakeTool))
+            return null;
+
+        if (!json.TryGetProperty("tool_input", out var toolInput) ||
+            toolInput.ValueKind != JsonValueKind.Object)
+            return null;
+
+        if (!TryGetCommand(toolInput, out var cmd))
+            return null;
+
+        return new AgentHookInput("Bash", cmd, json);
     }
 
     public AgentHookOutput Format(HookDecision decision, AgentHookInput input)
@@ -73,6 +103,51 @@ public sealed class CopilotCliAdapter : IAgentHarnessAdapter
         return new UninstallPlan([
             new UninstallOperation.NotSupported("Manual config required — remove hooks from VS Code settings manually"),
         ]);
+    }
+
+    private static bool TryExtractCommandFromToolArgs(JsonElement json, out string command)
+    {
+        command = "";
+        if (!json.TryGetProperty("toolArgs", out var toolArgsEl))
+            return false;
+
+        switch (toolArgsEl.ValueKind)
+        {
+            case JsonValueKind.String:
+            {
+                var s = toolArgsEl.GetString();
+                if (string.IsNullOrEmpty(s))
+                    return false;
+                try
+                {
+                    using var doc = JsonDocument.Parse(s);
+                    return TryGetCommand(doc.RootElement, out command);
+                }
+                catch (JsonException)
+                {
+                    return false;
+                }
+            }
+            case JsonValueKind.Object:
+                return TryGetCommand(toolArgsEl, out command);
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryGetCommand(JsonElement argsRoot, out string command)
+    {
+        command = "";
+        if (!argsRoot.TryGetProperty("command", out var commandEl) ||
+            commandEl.ValueKind != JsonValueKind.String)
+            return false;
+
+        var c = commandEl.GetString();
+        if (string.IsNullOrEmpty(c))
+            return false;
+
+        command = c;
+        return true;
     }
 
     private static AgentHookOutput FormatModifiedArgs(string command)

--- a/src/Hypa.Infrastructure/Hooks/Adapters/CopilotCliAdapter.cs
+++ b/src/Hypa.Infrastructure/Hooks/Adapters/CopilotCliAdapter.cs
@@ -114,20 +114,20 @@ public sealed class CopilotCliAdapter : IAgentHarnessAdapter
         switch (toolArgsEl.ValueKind)
         {
             case JsonValueKind.String:
-            {
-                var s = toolArgsEl.GetString();
-                if (string.IsNullOrEmpty(s))
-                    return false;
-                try
                 {
-                    using var doc = JsonDocument.Parse(s);
-                    return TryGetCommand(doc.RootElement, out command);
+                    var s = toolArgsEl.GetString();
+                    if (string.IsNullOrEmpty(s))
+                        return false;
+                    try
+                    {
+                        using var doc = JsonDocument.Parse(s);
+                        return TryGetCommand(doc.RootElement, out command);
+                    }
+                    catch (JsonException)
+                    {
+                        return false;
+                    }
                 }
-                catch (JsonException)
-                {
-                    return false;
-                }
-            }
             case JsonValueKind.Object:
                 return TryGetCommand(toolArgsEl, out command);
             default:

--- a/tests/Hypa.UnitTests/Cli/HookAutoDetectTests.cs
+++ b/tests/Hypa.UnitTests/Cli/HookAutoDetectTests.cs
@@ -1,0 +1,378 @@
+using System.CommandLine;
+using System.Text.Json;
+using Hypa.Cli.Commands;
+using Hypa.Infrastructure.Hooks;
+using Hypa.Infrastructure.Hooks.Adapters;
+using Hypa.Infrastructure.Rewrite;
+using Hypa.Infrastructure.Skills;
+using Hypa.Runtime.Application.Ports;
+using Hypa.Runtime.Application.Services;
+using Hypa.Runtime.Domain.Common;
+using Hypa.Runtime.Domain.Config;
+using Hypa.Runtime.Domain.Hooks;
+using NSubstitute;
+using Xunit;
+
+namespace Hypa.UnitTests.Cli;
+
+/// <summary>
+/// End-to-end auto-detect tests for <c>hypa hook</c> with the full DI registration order.
+/// Adapter identity is inferred from Format body shape (not private ResolveAdapter methods).
+/// </summary>
+public sealed class HookAutoDetectTests
+{
+    private static readonly SkillRenderer Renderer = new();
+
+    private readonly IHookIo _io;
+    private readonly HookCommand _command;
+    private readonly HarnessRegistry _registry;
+
+    public HookAutoDetectTests()
+    {
+        _io = Substitute.For<IHookIo>();
+        _registry = CreateProductionOrderedRegistry();
+
+        var lexer = new ShellLexer();
+        var wrapper = new GenericWrapperStrategy();
+        var strategies = new ICommandRewriteStrategy[]
+        {
+            new GitRewriteStrategy(),
+            new DotnetRewriteStrategy(),
+            new PackageManagerRewriteStrategy(),
+            new TscRewriteStrategy(),
+            new DockerRewriteStrategy(),
+            new KubectlRewriteStrategy(),
+            wrapper,
+        };
+        var rewriteRegistry = new CommandRewriteRegistry(lexer, strategies, wrapper);
+        var configLoader = Substitute.For<IConfigLoader>();
+        configLoader.LoadAsync(default).ReturnsForAnyArgs(
+            Task.FromResult(Result<HypaConfig, Error>.Ok(HypaConfig.Default)));
+        var rewriteService = new CommandRewriteService(configLoader, rewriteRegistry);
+        var readRedirector = Substitute.For<IReadRedirector>();
+        readRedirector.RedirectAsync(default!, default).ReturnsForAnyArgs(Task.FromResult<string?>(null));
+        var hookService = new HookService(rewriteService, readRedirector);
+
+        _command = new HookCommand(_io, _registry, hookService);
+    }
+
+    private static HarnessRegistry CreateProductionOrderedRegistry() => new([
+        new ClaudeCodeAdapter(Renderer),
+        new CopilotVscodeAdapter(),
+        new CopilotCliAdapter(),
+        new CodexAdapter(Renderer),
+        new PiAdapter(),
+    ]);
+
+    [Fact]
+    public void Registry_Order_MatchesDiRegistration()
+    {
+        Assert.Equal(
+            new[] { "claude", "copilot-vscode", "copilot-cli", "codex", "pi" },
+            _registry.All.Select(a => a.Key).ToArray());
+    }
+
+    [Fact]
+    public async Task AutoDetect_ScenarioA_PascalCaseCopilot_EmitsModifiedArgs()
+    {
+        // Issue #52 Scenario A — must not produce updatedInput (Claude) or hookSpecificOutput (Codex).
+        var payload = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "session_id": "61eb593e-2b98-4481-8293-bc3667aa96b7",
+              "timestamp": "2026-07-08T10:51:48.535Z",
+              "cwd": "C:\\SoftwareDev\\real-time-locating-system",
+              "tool_name": "Bash",
+              "tool_input": {
+                "command": "git status",
+                "description": "Show git status"
+              }
+            }
+            """);
+        _io.ReadStdinAsync(default).ReturnsForAnyArgs(Task.FromResult<JsonElement?>(payload));
+
+        AgentHookOutput? written = null;
+        _io.When(x => x.WriteOutput(Arg.Any<AgentHookOutput>()))
+            .Do(ci => written = ci.Arg<AgentHookOutput>());
+
+        var exitCode = await _command.Build().InvokeAsync([]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(written);
+        Assert.NotNull(written.JsonBody);
+        Assert.Contains("modifiedArgs", written.JsonBody);
+        Assert.Contains("hypa", written.JsonBody, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("updatedInput", written.JsonBody);
+        Assert.DoesNotContain("hookSpecificOutput", written.JsonBody);
+    }
+
+    [Fact]
+    public async Task AutoDetect_ScenarioA_DoesNotMatchCodex()
+    {
+        var payload = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "tool_name": "Bash",
+              "tool_input": {"command":"git status"}
+            }
+            """);
+        _io.ReadStdinAsync(default).ReturnsForAnyArgs(Task.FromResult<JsonElement?>(payload));
+
+        AgentHookOutput? written = null;
+        _io.When(x => x.WriteOutput(Arg.Any<AgentHookOutput>()))
+            .Do(ci => written = ci.Arg<AgentHookOutput>());
+
+        var exitCode = await _command.Build().InvokeAsync([]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(written?.JsonBody);
+        // Codex rewrite-as-deny uses hookSpecificOutput / "Use: " phrasing.
+        Assert.DoesNotContain("hookSpecificOutput", written.JsonBody);
+        Assert.DoesNotContain("\"decision\"", written.JsonBody);
+        Assert.Contains("modifiedArgs", written.JsonBody);
+        Assert.Contains("hypa", written.JsonBody, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AutoDetect_ScenarioB_PowerShell_EmitsModifiedArgs()
+    {
+        var payload = ParseJson("""
+            {
+              "sessionId": "1e194835-92e7-44dd-ab13-9adf7db6e568",
+              "timestamp": 1783508050028,
+              "cwd": "C:\\SoftwareDev\\real-time-locating-system",
+              "toolName": "powershell",
+              "toolArgs": "{\"command\":\"git status\",\"description\":\"Show git status\"}"
+            }
+            """);
+        _io.ReadStdinAsync(default).ReturnsForAnyArgs(Task.FromResult<JsonElement?>(payload));
+
+        AgentHookOutput? written = null;
+        _io.When(x => x.WriteOutput(Arg.Any<AgentHookOutput>()))
+            .Do(ci => written = ci.Arg<AgentHookOutput>());
+
+        var exitCode = await _command.Build().InvokeAsync([]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(written);
+        Assert.NotNull(written.JsonBody);
+        Assert.Contains("modifiedArgs", written.JsonBody);
+        Assert.Contains("hypa", written.JsonBody, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("updatedInput", written.JsonBody);
+        Assert.DoesNotContain("hookSpecificOutput", written.JsonBody);
+    }
+
+    [Fact]
+    public async Task AutoDetect_ClaudeWithMarkers_EmitsUpdatedInput()
+    {
+        var payload = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "transcript_path": "/tmp/hypa-test-transcript.jsonl",
+              "permission_mode": "default",
+              "tool_name": "Bash",
+              "tool_input": {"command":"git status"}
+            }
+            """);
+        _io.ReadStdinAsync(default).ReturnsForAnyArgs(Task.FromResult<JsonElement?>(payload));
+
+        AgentHookOutput? written = null;
+        _io.When(x => x.WriteOutput(Arg.Any<AgentHookOutput>()))
+            .Do(ci => written = ci.Arg<AgentHookOutput>());
+
+        var exitCode = await _command.Build().InvokeAsync([]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(written);
+        Assert.NotNull(written.JsonBody);
+        Assert.Contains("updatedInput", written.JsonBody);
+        Assert.Contains("hypa", written.JsonBody, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("modifiedArgs", written.JsonBody);
+        Assert.DoesNotContain("hookSpecificOutput", written.JsonBody);
+    }
+
+    [Fact]
+    public async Task AutoDetect_CopilotVscode_RunInTerminal_EmitsUpdatedInput()
+    {
+        var payload = ParseJson("""
+            {
+              "tool_name": "run_in_terminal",
+              "tool_input": {"command":"git status"}
+            }
+            """);
+        _io.ReadStdinAsync(default).ReturnsForAnyArgs(Task.FromResult<JsonElement?>(payload));
+
+        AgentHookOutput? written = null;
+        _io.When(x => x.WriteOutput(Arg.Any<AgentHookOutput>()))
+            .Do(ci => written = ci.Arg<AgentHookOutput>());
+
+        var exitCode = await _command.Build().InvokeAsync([]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(written);
+        Assert.NotNull(written.JsonBody);
+        // VS Code Copilot Format uses updatedInput (same key as Claude Format).
+        Assert.Contains("updatedInput", written.JsonBody);
+        Assert.Contains("hypa", written.JsonBody, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("modifiedArgs", written.JsonBody);
+    }
+
+    [Fact]
+    public async Task AutoDetect_CodexShell_EmitsHookSpecificOutput()
+    {
+        // Codex-shaped payload without hook_event_name or toolName — only tool_name shell.
+        var payload = ParseJson("""
+            {
+              "tool_name": "Shell",
+              "tool_input": {"command":"git status"}
+            }
+            """);
+        _io.ReadStdinAsync(default).ReturnsForAnyArgs(Task.FromResult<JsonElement?>(payload));
+
+        AgentHookOutput? written = null;
+        _io.When(x => x.WriteOutput(Arg.Any<AgentHookOutput>()))
+            .Do(ci => written = ci.Arg<AgentHookOutput>());
+
+        var exitCode = await _command.Build().InvokeAsync([]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(written);
+        Assert.NotNull(written.JsonBody);
+        Assert.Contains("hookSpecificOutput", written.JsonBody);
+        Assert.Contains("hypa", written.JsonBody, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("modifiedArgs", written.JsonBody);
+        Assert.DoesNotContain("updatedInput", written.JsonBody);
+    }
+
+    [Fact]
+    public async Task ExplicitAgent_CopilotCli_ScenarioA_EmitsModifiedArgs()
+    {
+        var payload = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "tool_name": "Bash",
+              "tool_input": {"command":"git status"}
+            }
+            """);
+        _io.ReadStdinAsync(default).ReturnsForAnyArgs(Task.FromResult<JsonElement?>(payload));
+
+        AgentHookOutput? written = null;
+        _io.When(x => x.WriteOutput(Arg.Any<AgentHookOutput>()))
+            .Do(ci => written = ci.Arg<AgentHookOutput>());
+
+        var exitCode = await _command.Build().InvokeAsync(["--agent", "copilot-cli"]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(written?.JsonBody);
+        Assert.Contains("modifiedArgs", written.JsonBody);
+        Assert.Contains("hypa", written.JsonBody, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExplicitAgent_CopilotCli_ScenarioB_EmitsModifiedArgs()
+    {
+        var payload = ParseJson("""
+            {
+              "sessionId": "1e194835-92e7-44dd-ab13-9adf7db6e568",
+              "timestamp": 1783508050028,
+              "cwd": "C:\\SoftwareDev\\real-time-locating-system",
+              "toolName": "powershell",
+              "toolArgs": "{\"command\":\"git status\",\"description\":\"Show git status\"}"
+            }
+            """);
+        _io.ReadStdinAsync(default).ReturnsForAnyArgs(Task.FromResult<JsonElement?>(payload));
+
+        AgentHookOutput? written = null;
+        _io.When(x => x.WriteOutput(Arg.Any<AgentHookOutput>()))
+            .Do(ci => written = ci.Arg<AgentHookOutput>());
+
+        var exitCode = await _command.Build().InvokeAsync(["--agent", "copilot-cli"]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(written?.JsonBody);
+        Assert.Contains("modifiedArgs", written.JsonBody);
+        Assert.Contains("hypa", written.JsonBody, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExplicitAgent_Claude_ScenarioA_NoRewrite()
+    {
+        // Scenario A is not a Claude payload; --agent claude Parse returns null → exit 0, no write.
+        var payload = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "tool_name": "Bash",
+              "tool_input": {"command":"git status"}
+            }
+            """);
+        _io.ReadStdinAsync(default).ReturnsForAnyArgs(Task.FromResult<JsonElement?>(payload));
+
+        var exitCode = await _command.Build().InvokeAsync(["--agent", "claude"]);
+
+        Assert.Equal(0, exitCode);
+        _io.DidNotReceive().WriteOutput(Arg.Any<AgentHookOutput>());
+    }
+
+    [Fact]
+    public void ParseOrder_ScenarioA_MatchesCopilotCli()
+    {
+        var json = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "tool_name": "Bash",
+              "tool_input": {"command":"git status"}
+            }
+            """);
+        var (key, input) = FirstMatch(json);
+        Assert.Equal("copilot-cli", key);
+        Assert.NotNull(input);
+        Assert.Equal("git status", input.Command);
+    }
+
+    [Fact]
+    public void ParseOrder_ScenarioB_MatchesCopilotCli()
+    {
+        var json = ParseJson("""
+            {
+              "toolName": "powershell",
+              "toolArgs": "{\"command\":\"git status\"}"
+            }
+            """);
+        var (key, input) = FirstMatch(json);
+        Assert.Equal("copilot-cli", key);
+        Assert.NotNull(input);
+        Assert.Equal("git status", input.Command);
+    }
+
+    [Fact]
+    public void ParseOrder_ClaudeMarkers_MatchesClaude()
+    {
+        var json = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "transcript_path": "/tmp/t.jsonl",
+              "permission_mode": "default",
+              "tool_name": "Bash",
+              "tool_input": {"command":"git status"}
+            }
+            """);
+        var (key, input) = FirstMatch(json);
+        Assert.Equal("claude", key);
+        Assert.NotNull(input);
+    }
+
+    private (string? Key, AgentHookInput? Input) FirstMatch(JsonElement json)
+    {
+        foreach (var candidate in _registry.All)
+        {
+            var parsed = candidate.Parse(json);
+            if (parsed is not null)
+                return (candidate.Key, parsed);
+        }
+
+        return (null, null);
+    }
+
+    private static JsonElement ParseJson(string json) =>
+        JsonDocument.Parse(json).RootElement.Clone();
+}

--- a/tests/Hypa.UnitTests/Infrastructure/Hooks/ClaudeCodeAdapterTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Hooks/ClaudeCodeAdapterTests.cs
@@ -15,7 +15,7 @@ public sealed class ClaudeCodeAdapterTests
     [Fact]
     public void Parse_BashToolWithCommand_ReturnsInput()
     {
-        var json = ParseJson("""{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git status"}}""");
+        var json = ClaudePreToolUseJson("Bash", """{"command":"git status"}""");
         var result = _adapter.Parse(json);
         Assert.NotNull(result);
         Assert.Equal("Bash", result.ToolName);
@@ -32,7 +32,7 @@ public sealed class ClaudeCodeAdapterTests
     [Fact]
     public void Parse_ReadTool_ReturnsInputWithPath()
     {
-        var json = ParseJson("""{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"path":"/tmp/foo"}}""");
+        var json = ClaudePreToolUseJson("Read", """{"path":"/tmp/foo"}""");
         var result = _adapter.Parse(json);
         Assert.NotNull(result);
         Assert.Equal("Read", result.ToolName);
@@ -42,7 +42,7 @@ public sealed class ClaudeCodeAdapterTests
     [Fact]
     public void Parse_OtherTool_ReturnsPassthroughInput()
     {
-        var json = ParseJson("""{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{}}""");
+        var json = ClaudePreToolUseJson("Edit", "{}");
         var result = _adapter.Parse(json);
         Assert.NotNull(result);
         Assert.Equal("Edit", result.ToolName);
@@ -51,14 +51,97 @@ public sealed class ClaudeCodeAdapterTests
     [Fact]
     public void Parse_MissingToolName_ReturnsNull()
     {
-        var json = ParseJson("""{"hook_event_name":"PreToolUse","tool_input":{"command":"git status"}}""");
+        // Markers present so we pass the marker gate and exercise post-gate tool_name missing.
+        var json = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "transcript_path": "/tmp/hypa-test-transcript.jsonl",
+              "permission_mode": "default",
+              "tool_input": {"command":"git status"}
+            }
+            """);
         Assert.Null(_adapter.Parse(json));
     }
 
     [Fact]
     public void Parse_MissingCommand_ReturnsNull()
     {
-        var json = ParseJson("""{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{}}""");
+        // Markers present so we pass the marker gate and exercise Bash without command.
+        var json = ClaudePreToolUseJson("Bash", "{}");
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_EmptyCommand_ReturnsNull()
+    {
+        var json = ClaudePreToolUseJson("Bash", """{"command":""}""");
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_CopilotPascalCase_NoMarkers_ReturnsNull()
+    {
+        // Issue #52 Scenario A: Copilot PascalCase PreToolUse without Claude markers.
+        var json = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "session_id": "61eb593e-2b98-4481-8293-bc3667aa96b7",
+              "timestamp": "2026-07-08T10:51:48.535Z",
+              "cwd": "C:\\SoftwareDev\\real-time-locating-system",
+              "tool_name": "Bash",
+              "tool_input": {
+                "command": "git status",
+                "description": "Show git status"
+              }
+            }
+            """);
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Theory]
+    [InlineData("transcript_path", "/tmp/t.jsonl")]
+    [InlineData("permission_mode", "default")]
+    [InlineData("tool_use_id", "toolu_abc123")]
+    public void Parse_SingleNonEmptyMarker_StillMatches(string markerName, string markerValue)
+    {
+        var json = ParseJson($$"""
+            {
+              "hook_event_name": "PreToolUse",
+              "{{markerName}}": "{{markerValue}}",
+              "tool_name": "Bash",
+              "tool_input": {"command":"git status"}
+            }
+            """);
+        var result = _adapter.Parse(json);
+        Assert.NotNull(result);
+        Assert.Equal("git status", result.Command);
+    }
+
+    [Fact]
+    public void Parse_EmptyPermissionModeOnly_ReturnsNull()
+    {
+        var json = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "permission_mode": "",
+              "tool_name": "Bash",
+              "tool_input": {"command":"git status"}
+            }
+            """);
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_NullPermissionModeOnly_ReturnsNull()
+    {
+        var json = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "permission_mode": null,
+              "tool_name": "Bash",
+              "tool_input": {"command":"git status"}
+            }
+            """);
         Assert.Null(_adapter.Parse(json));
     }
 
@@ -74,6 +157,8 @@ public sealed class ClaudeCodeAdapterTests
         Assert.NotNull(output.JsonBody);
         Assert.Contains("updatedInput", output.JsonBody);
         Assert.Contains("hypa git status", output.JsonBody);
+        Assert.DoesNotContain("modifiedArgs", output.JsonBody);
+        Assert.DoesNotContain("hookSpecificOutput", output.JsonBody);
     }
 
     [Fact]
@@ -237,8 +322,26 @@ public sealed class ClaudeCodeAdapterTests
         Assert.Throws<ArgumentException>(() => _adapter.GetUninstallPlan(global: false));
     }
 
+    /// <summary>
+    /// Always inject Claude envelope markers used by production PreToolUse.
+    /// Happy-path default: transcript_path + permission_mode (not tool_use_id).
+    /// </summary>
+    private static JsonElement ClaudePreToolUseJson(string toolName, string toolInputObjectJson)
+    {
+        var json = $$"""
+            {
+              "hook_event_name": "PreToolUse",
+              "transcript_path": "/tmp/hypa-test-transcript.jsonl",
+              "permission_mode": "default",
+              "tool_name": "{{toolName}}",
+              "tool_input": {{toolInputObjectJson}}
+            }
+            """;
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
     private static JsonElement ParseJson(string json) =>
-        JsonDocument.Parse(json).RootElement;
+        JsonDocument.Parse(json).RootElement.Clone();
 
     private static AgentHookInput MakeInput(string command) =>
         new("Bash", command, ParseJson($$$"""{"tool_name":"Bash","tool_input":{"command":"{{{command}}}"}}"""));

--- a/tests/Hypa.UnitTests/Infrastructure/Hooks/CopilotCliAdapterTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Hooks/CopilotCliAdapterTests.cs
@@ -130,6 +130,17 @@ public sealed class CopilotCliAdapterTests
         Assert.Null(_adapter.Parse(json));
     }
 
+    [Theory]
+    [InlineData("""{"toolName":"bash","toolArgs":"42"}""")]
+    [InlineData("""{"toolName":"bash","toolArgs":"null"}""")]
+    [InlineData("""{"toolName":"bash","toolArgs":"[]"}""")]
+    [InlineData("""{"toolName":"bash","toolArgs":"\"git status\""}""")]
+    public void Parse_StringToolArgsNonObjectJsonRoot_ReturnsNull(string payload)
+    {
+        // toolArgs string that parses to a non-object root must return null, not throw.
+        Assert.Null(_adapter.Parse(ParseJson(payload)));
+    }
+
     [Fact]
     public void Parse_PascalCaseScenarioA_ReturnsInput()
     {

--- a/tests/Hypa.UnitTests/Infrastructure/Hooks/CopilotCliAdapterTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Hooks/CopilotCliAdapterTests.cs
@@ -19,10 +19,65 @@ public sealed class CopilotCliAdapterTests
         Assert.Equal("Bash", result.ToolName);
     }
 
-    [Fact]
-    public void Parse_NonBashTool_ReturnsNull()
+    [Theory]
+    [InlineData("bash")]
+    [InlineData("Bash")]
+    [InlineData("BASH")]
+    [InlineData("powershell")]
+    [InlineData("PowerShell")]
+    public void Parse_ShellToolNameCaseVariants_ReturnInput(string toolName)
     {
-        var json = ParseJson("""{"toolName":"read","toolArgs":"{\"path\":\"/tmp\"}"}""");
+        var json = ParseJson($$"""{"toolName":"{{toolName}}","toolArgs":"{\"command\":\"git status\"}"}""");
+        var result = _adapter.Parse(json);
+        Assert.NotNull(result);
+        Assert.Equal("git status", result.Command);
+        Assert.Equal("Bash", result.ToolName);
+    }
+
+    [Fact]
+    public void Parse_PowerShell_ScenarioB_ReturnsInput()
+    {
+        // Issue #52 Scenario B: native camelCase preToolUse on Windows.
+        var json = ParseJson("""
+            {
+              "sessionId": "1e194835-92e7-44dd-ab13-9adf7db6e568",
+              "timestamp": 1783508050028,
+              "cwd": "C:\\SoftwareDev\\real-time-locating-system",
+              "toolName": "powershell",
+              "toolArgs": "{\"command\":\"git -C \\\"C:\\\\SoftwareDev\\\\real-time-locating-system\\\" --no-pager status --short --branch\",\"description\":\"Show git status for repository\"}"
+            }
+            """);
+        var result = _adapter.Parse(json);
+        Assert.NotNull(result);
+        Assert.Equal("Bash", result.ToolName);
+        Assert.Contains("git -C", result.Command);
+        Assert.Contains("status --short --branch", result.Command);
+    }
+
+    [Fact]
+    public void Parse_ToolArgsAsObject_ReturnsInput()
+    {
+        var json = ParseJson("""{"toolName":"bash","toolArgs":{"command":"git status"}}""");
+        var result = _adapter.Parse(json);
+        Assert.NotNull(result);
+        Assert.Equal("git status", result.Command);
+        Assert.Equal("Bash", result.ToolName);
+    }
+
+    [Fact]
+    public void Parse_NonShellTool_ReturnsNull()
+    {
+        var json = ParseJson("""{"toolName":"view","toolArgs":"{\"path\":\"/tmp\"}"}""");
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Theory]
+    [InlineData("pwsh")]
+    [InlineData("cmd")]
+    [InlineData("Shell")]
+    public void Parse_NonAcceptedShellAliases_ReturnNull(string toolName)
+    {
+        var json = ParseJson($$"""{"toolName":"{{toolName}}","toolArgs":"{\"command\":\"git status\"}"}""");
         Assert.Null(_adapter.Parse(json));
     }
 
@@ -30,6 +85,177 @@ public sealed class CopilotCliAdapterTests
     public void Parse_InvalidToolArgsJson_ReturnsNull()
     {
         var json = ParseJson("""{"toolName":"bash","toolArgs":"not-json"}""");
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_MissingToolArgs_ReturnsNull()
+    {
+        var json = ParseJson("""{"toolName":"bash"}""");
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_EmptyStringToolArgs_ReturnsNull()
+    {
+        var json = ParseJson("""{"toolName":"bash","toolArgs":""}""");
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_ObjectToolArgsWithoutCommand_ReturnsNull()
+    {
+        var json = ParseJson("""{"toolName":"bash","toolArgs":{"description":"no command"}}""");
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_ObjectToolArgsEmptyCommand_ReturnsNull()
+    {
+        var json = ParseJson("""{"toolName":"bash","toolArgs":{"command":""}}""");
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_NonObjectNonStringToolArgs_ReturnsNull()
+    {
+        var json = ParseJson("""{"toolName":"bash","toolArgs":42}""");
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_StringToolArgsEmptyCommand_ReturnsNull()
+    {
+        var json = ParseJson("""{"toolName":"bash","toolArgs":"{\"command\":\"\"}"}""");
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_PascalCaseScenarioA_ReturnsInput()
+    {
+        // Issue #52 Scenario A: PascalCase PreToolUse without Claude markers.
+        var json = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "session_id": "61eb593e-2b98-4481-8293-bc3667aa96b7",
+              "timestamp": "2026-07-08T10:51:48.535Z",
+              "cwd": "C:\\SoftwareDev\\real-time-locating-system",
+              "tool_name": "Bash",
+              "tool_input": {
+                "command": "git status",
+                "description": "Show git status"
+              }
+            }
+            """);
+        var result = _adapter.Parse(json);
+        Assert.NotNull(result);
+        Assert.Equal("Bash", result.ToolName);
+        Assert.Equal("git status", result.Command);
+    }
+
+    [Fact]
+    public void Parse_PascalCaseWithClaudeMarker_ReturnsNull()
+    {
+        var json = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "transcript_path": "/tmp/t.jsonl",
+              "tool_name": "Bash",
+              "tool_input": {"command":"git status"}
+            }
+            """);
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Theory]
+    [InlineData("""{"hook_event_name":"PreToolUse","permission_mode":"","tool_name":"Bash","tool_input":{"command":"git status"}}""")]
+    [InlineData("""{"hook_event_name":"PreToolUse","permission_mode":null,"tool_name":"Bash","tool_input":{"command":"git status"}}""")]
+    [InlineData("""{"hook_event_name":"PreToolUse","transcript_path":"","tool_name":"Bash","tool_input":{"command":"git status"}}""")]
+    [InlineData("""{"hook_event_name":"PreToolUse","tool_use_id":null,"tool_name":"Bash","tool_input":{"command":"git status"}}""")]
+    public void Parse_PascalCase_EmptyOrNullMarkerFields_StillMatches(string jsonText)
+    {
+        // Empty/null marker fields do not count as Claude markers (non-empty string rule).
+        var json = ParseJson(jsonText);
+        var result = _adapter.Parse(json);
+        Assert.NotNull(result);
+        Assert.Equal("git status", result.Command);
+    }
+
+    [Fact]
+    public void Parse_PascalCaseNonShell_ReturnsNull()
+    {
+        var json = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "tool_name": "Read",
+              "tool_input": {"path":"/tmp/foo"}
+            }
+            """);
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_PascalCasePostToolUse_ReturnsNull()
+    {
+        var json = ParseJson("""
+            {
+              "hook_event_name": "PostToolUse",
+              "tool_name": "Bash",
+              "tool_input": {"command":"git status"}
+            }
+            """);
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_PascalCaseWrongEventNameCasing_ReturnsNull()
+    {
+        // Ordinal gate: camelCase preToolUse is not PreToolUse on the PascalCase path.
+        var json = ParseJson("""
+            {
+              "hook_event_name": "preToolUse",
+              "tool_name": "Bash",
+              "tool_input": {"command":"git status"}
+            }
+            """);
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_PascalCaseMissingToolInput_ReturnsNull()
+    {
+        var json = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "tool_name": "Bash"
+            }
+            """);
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_PascalCaseNonObjectToolInput_ReturnsNull()
+    {
+        var json = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "tool_name": "Bash",
+              "tool_input": "git status"
+            }
+            """);
+        Assert.Null(_adapter.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_PascalCaseEmptyCommand_ReturnsNull()
+    {
+        var json = ParseJson("""
+            {
+              "hook_event_name": "PreToolUse",
+              "tool_name": "Bash",
+              "tool_input": {"command":""}
+            }
+            """);
         Assert.Null(_adapter.Parse(json));
     }
 
@@ -46,6 +272,8 @@ public sealed class CopilotCliAdapterTests
         Assert.Contains(@"hypa -c \u0022git status\u0022", output.JsonBody);
         Assert.DoesNotContain("permissionDecision", output.JsonBody);
         Assert.DoesNotContain("deny", output.JsonBody);
+        Assert.DoesNotContain("updatedInput", output.JsonBody);
+        Assert.DoesNotContain("hookSpecificOutput", output.JsonBody);
     }
 
     [Fact]
@@ -54,9 +282,14 @@ public sealed class CopilotCliAdapterTests
         var input = MakeInput("rm -rf /");
         var decision = new HookDecision.Deny("Command blocked");
         var output = _adapter.Format(decision, input);
+        Assert.Equal(0, output.ExitCode);
         Assert.NotNull(output.JsonBody);
+        Assert.Contains("permissionDecision", output.JsonBody);
         Assert.Contains("deny", output.JsonBody);
         Assert.Contains("Command blocked", output.JsonBody);
+        Assert.DoesNotContain("modifiedArgs", output.JsonBody);
+        Assert.DoesNotContain("updatedInput", output.JsonBody);
+        Assert.DoesNotContain("hookSpecificOutput", output.JsonBody);
     }
 
     [Fact]
@@ -65,10 +298,15 @@ public sealed class CopilotCliAdapterTests
         var input = MakeInput("git push");
         var decision = new HookDecision.Ask("Confirm?");
         var output = _adapter.Format(decision, input);
+        Assert.Equal(0, output.ExitCode);
         Assert.NotNull(output.JsonBody);
+        Assert.Contains("permissionDecision", output.JsonBody);
         Assert.Contains("ask", output.JsonBody);
         Assert.Contains("Confirm?", output.JsonBody);
         Assert.DoesNotContain("deny", output.JsonBody);
+        Assert.DoesNotContain("modifiedArgs", output.JsonBody);
+        Assert.DoesNotContain("updatedInput", output.JsonBody);
+        Assert.DoesNotContain("hookSpecificOutput", output.JsonBody);
     }
 
     [Fact]
@@ -86,7 +324,7 @@ public sealed class CopilotCliAdapterTests
     }
 
     private static JsonElement ParseJson(string json) =>
-        JsonDocument.Parse(json).RootElement;
+        JsonDocument.Parse(json).RootElement.Clone();
 
     private static AgentHookInput MakeInput(string command) =>
         new("bash", command, ParseJson("{}"));


### PR DESCRIPTION
## Summary

- Fix `hypa hook` auto-detect for GitHub Copilot CLI PreToolUse payloads (Closes #52).
- **Scenario A (PascalCase):** stop greedy Claude matching on marker-less `hook_event_name` payloads so Copilot rewrites use `modifiedArgs` instead of ignored `updatedInput`.
- **Scenario B (camelCase):** accept Windows `powershell` (and `bash`) shell tools on the native Copilot path.
- Add shared Claude envelope markers, dual-format CopilotCli parsing, and registry-order auto-detect tests.

## Test plan

- [x] `dotnet test tests/Hypa.UnitTests/Hypa.UnitTests.csproj --filter "FullyQualifiedName~Hooks|FullyQualifiedName~Hook"` (286 passed)
- [ ] CI unit + golden tests green
- [ ] Manual (optional): pipe Scenario A/B payloads from #52 into `hypa hook` and confirm `modifiedArgs` stdout