### PR TITLE
feat(filters): recognise bun/bunx/bun-run as package runner prefixes

### DIFF
--- a/src/Hypa.Infrastructure/Filters/BuiltInFilters.cs
+++ b/src/Hypa.Infrastructure/Filters/BuiltInFilters.cs
@@ -162,8 +162,8 @@ public static class BuiltInFilters
         {
             Id = "jest",
             Description = "Compact Jest and Vitest test output; keep failures and summary.",
-            AppliesTo = ["jest", "vitest", "npx", "pnpm"],
-            MatchCommand = @"^((npx|pnpm)\s+)?(jest|vitest)\b",
+            AppliesTo = ["jest", "vitest", "npx", "pnpm", "bunx", "bun"],
+            MatchCommand = @"^((?:npx|pnpm|bunx|bun\s+(?:x|run))\s+)?(jest|vitest)\b",
             Scope = FilterScope.BuiltIn,
             Stages =
             [
@@ -277,8 +277,8 @@ public static class BuiltInFilters
         {
             Id = "mocha",
             Description = "Compact Mocha test output into pass/fail summary.",
-            AppliesTo = ["mocha", "npx", "pnpm"],
-            MatchCommand = @"^((npx|pnpm)\s+)?mocha\b",
+            AppliesTo = ["mocha", "npx", "pnpm", "bunx", "bun"],
+            MatchCommand = @"^((?:npx|pnpm|bunx|bun\s+(?:x|run))\s+)?mocha\b",
             Scope = FilterScope.BuiltIn,
             Stages =
             [
@@ -319,8 +319,8 @@ public static class BuiltInFilters
         {
             Id = "playwright",
             Description = "Compact Playwright test output and preserve failure artifact paths.",
-            AppliesTo = ["playwright", "npx", "pnpm"],
-            MatchCommand = @"^((npx|pnpm)\s+)?playwright\s+test\b",
+            AppliesTo = ["playwright", "npx", "pnpm", "bunx", "bun"],
+            MatchCommand = @"^((?:npx|pnpm|bunx|bun\s+(?:x|run))\s+)?playwright\s+test\b",
             Scope = FilterScope.BuiltIn,
             Stages =
             [

--- a/tests/Hypa.UnitTests/Infrastructure/Filters/BuiltInFiltersTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Filters/BuiltInFiltersTests.cs
@@ -146,6 +146,24 @@ public sealed class BuiltInFiltersTests
     }
 
     [Fact]
+    public void GetApplicableFilters_RecognisesBunRunnerPrefixes()
+    {
+        var service = MakeService(BuiltInFilters.All);
+
+        var bunxVitest = service.GetApplicableFilters("bunx", "bunx vitest run");
+        var bunXVitest = service.GetApplicableFilters("bun", "bun x vitest run");
+        var bunRunVitest = service.GetApplicableFilters("bun", "bun run vitest");
+        var bunxMocha = service.GetApplicableFilters("bunx", "bunx mocha");
+        var bunxPlaywright = service.GetApplicableFilters("bunx", "bunx playwright test");
+
+        Assert.Contains(bunxVitest, f => f.Id == "jest");
+        Assert.Contains(bunXVitest, f => f.Id == "jest");
+        Assert.Contains(bunRunVitest, f => f.Id == "jest");
+        Assert.Contains(bunxMocha, f => f.Id == "mocha");
+        Assert.Contains(bunxPlaywright, f => f.Id == "playwright");
+    }
+
+    [Fact]
     public void Apply_Jest_DoesNotShortCircuitFailedSummary()
     {
         var filter = BuiltInFilters.All.Single(f => f.Id == "jest");


### PR DESCRIPTION
Jest/Vitest, Mocha and Playwright reducers already unwrap `npx`/`pnpm` prefixes but not Bun's, so `bunx vitest` (and `bun x` / `bun run`) fall through to no reduction.

This adds Bun runners to the existing prefix group and `AppliesTo`, matching the npx/pnpm behaviour:

- `MatchCommand`: `^((npx|pnpm)\s+)?` → `^((?:npx|pnpm|bunx|bun\s+(?:x|run))\s+)?`
- `AppliesTo`: add `bunx`, `bun`

Applies to the `jest` (jest/vitest), `mocha` and `playwright` reducers.

Adds a unit test (`GetApplicableFilters_RecognisesBunRunnerPrefixes`) mirroring the existing pnpm parity test.

### Testing note

I do not have a .NET SDK on this machine, so **I have not compiled or run the modified code or the test suite** — CI should confirm. What I did check: the new regex was validated independently (outside .NET) against positive cases (`bunx vitest run`, `bun x vitest run`, `bun run vitest`) and negatives that must NOT match (`bun test` — Bun's own runner, `bun run lint`, `bunx tsc`, `mybunx vitest`). Separately, `npx vitest run` / bare `vitest run` already reduce as expected on the current release, which is the behaviour this change extends to Bun runners.