### PR TITLE
Fix hypa_find on Windows by using ripgrep

### DIFF
--- a/packages/pi-hypa/extensions/tools.ts
+++ b/packages/pi-hypa/extensions/tools.ts
@@ -181,9 +181,8 @@ export function buildGrepCommand(params: {
 }
 
 export function buildFindCommand(params: { pattern?: string; path?: string; limit?: number }): string {
-  const path = shellQuote(normalizePathArg(params.path ?? "."));
-  const pattern = shellQuote(params.pattern ?? "*");
-  const base = `find ${path} -type f -name ${pattern}`;
+  const args = ["rg", "--files", "--glob", params.pattern ?? "*", normalizePathArg(params.path ?? ".")];
+  const base = args.map(shellQuote).join(" ");
   if (params.limit === undefined) return base;
   return `${base} | head -n ${shellQuote(String(Math.max(1, Math.floor(params.limit))))}`;
 }

--- a/packages/pi-hypa/test/tools.test.ts
+++ b/packages/pi-hypa/test/tools.test.ts
@@ -30,8 +30,13 @@ test("buildGrepCommand treats dash-leading patterns as data via -e", () => {
   assert.match(command, /\s-e\s--help\s--\s/);
 });
 
+test("buildFindCommand lists files with ripgrep", () => {
+  assert.equal(buildFindCommand({}), "rg --files --glob '*' .");
+  assert.equal(buildFindCommand({ pattern: "*.cs", path: "src" }), "rg --files --glob '*.cs' src");
+});
+
 test("buildFindCommand applies optional limit", () => {
-  assert.equal(buildFindCommand({ pattern: "*.cs", path: "src", limit: 10 }), "find src -type f -name '*.cs' | head -n 10");
+  assert.equal(buildFindCommand({ pattern: "*.cs", path: "src", limit: 10 }), "rg --files --glob '*.cs' src | head -n 10");
 });
 
 test("buildLsCommand defaults to long listing", () => {


### PR DESCRIPTION
## Summary
- Switch `buildFindCommand` from Unix `find … -type f -name` to `rg --files --glob` so hypa_find works on Windows (where bare `find` is FIND.exe).
- Match `buildGrepCommand` arg construction (`args.map(shellQuote).join(" ")`).
- Keep optional `| head -n N` limit (minimal change; full Windows limit support if `head` is missing can be a follow-up).
- Update/add unit tests for default args, unlimited, and limited forms.

## Notes
- Does not rewrite `shellQuote` (tracked separately, e.g. #56).
- Default `rg` ignore/hidden semantics match `hypa_grep`; intentional for consistency (not Unix-`find` full-filesystem parity).

## Test plan
- [x] `cd packages/pi-hypa && npm test` (53 tests pass)
- [ ] Smoke hypa_find on Windows if available

Closes #55