### PR TITLE
Fix shellQuote for Windows cmd.exe quoting

### DIFF
--- a/packages/pi-hypa/extensions/tools.ts
+++ b/packages/pi-hypa/extensions/tools.ts
@@ -1,5 +1,5 @@
 import { mkdtemp, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import { Text } from "@earendil-works/pi-tui";
 import type { HypaPiConfig } from "./types.js";
@@ -140,9 +140,26 @@ interface ToolTextDetails {
   fullOutputPath?: string;
 }
 
-export function shellQuote(value: string): string {
-  if (value.length === 0) return "''";
-  if (/^[A-Za-z0-9_./:=@,+%^-]+$/.test(value)) return value;
+const POSIX_SAFE_VALUE = /^[A-Za-z0-9_./:=@,+%^-]+$/;
+// Exclude cmd.exe metacharacters ^ (escape) and % (env expansion) from the unquoted fast path.
+const WINDOWS_SAFE_VALUE = /^[A-Za-z0-9_./:=@,+-]+$/;
+
+export function shellQuote(value: string, platformName: NodeJS.Platform = platform()): string {
+  if (value.length === 0) return platformName === "win32" ? '""' : "''";
+  const safeValue = platformName === "win32" ? WINDOWS_SAFE_VALUE : POSIX_SAFE_VALUE;
+  if (safeValue.test(value)) return value;
+  if (platformName === "win32") {
+    // cmd.exe double quotes (not POSIX single quotes). Fixes #56: cmd does not strip
+    // single-quoted tokens, so globs like *.py would arrive as literal '*.py'.
+    // StripQuotes peels outer quotes on Hypa's direct path without decoding escapes,
+    // so do NOT use MSVC \" encoding here (leaves backslashes in argv).
+    // shellQuote-only limitations (full fix needs ShellLexer/StripQuotes/RunCommand):
+    // - cmd "" doubling for embedded " is not decoded by ShellLexer (rare for paths/globs).
+    // - cmd expands %VAR% inside double quotes; no reliable escape (values are at least quoted).
+    // - trailing \ before closing " confuses ShellLexer backslash-as-escape parsing.
+    // - embedded \r or \n terminate cmd lines; callers should not pass newlines in paths.
+    return `"${value.replace(/"/g, `""`)}"`;
+  }
   return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
@@ -177,7 +194,8 @@ export function buildGrepCommand(params: {
   if (params.glob) args.push("--glob", params.glob);
   // -e treats the pattern as data (even if it starts with '-'); -- ends options before the path
   args.push("-e", params.pattern, "--", normalizePathArg(params.path ?? "."));
-  return args.map(shellQuote).join(" ");
+  // Explicit arrow: shellQuote's second param is platformName, not Array.map's index
+  return args.map((a) => shellQuote(a)).join(" ");
 }
 
 export function buildFindCommand(params: { pattern?: string; path?: string; limit?: number }): string {
@@ -192,7 +210,7 @@ export function buildLsCommand(params: { path?: string; all?: boolean; long?: bo
   const flags = `${params.long === false ? "" : "l"}${params.all ? "a" : ""}`;
   return ["ls", flags ? `-${flags}` : undefined, "--", normalizePathArg(params.path ?? ".")]
     .filter((value): value is string => typeof value === "string" && value.length > 0)
-    .map(shellQuote)
+    .map((a) => shellQuote(a))
     .join(" ");
 }
 

--- a/packages/pi-hypa/test/tools.test.ts
+++ b/packages/pi-hypa/test/tools.test.ts
@@ -2,10 +2,23 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { buildFindCommand, buildGrepCommand, buildLsCommand, buildReadCommand, shellQuote } from "../extensions/tools.js";
 
-test("shellQuote protects spaces and single quotes", () => {
-  assert.equal(shellQuote("simple/path"), "simple/path");
-  assert.equal(shellQuote("a b"), "'a b'");
-  assert.equal(shellQuote("it's"), "'it'\"'\"'s'");
+test("shellQuote protects spaces and single quotes on POSIX", () => {
+  assert.equal(shellQuote("simple/path", "linux"), "simple/path");
+  assert.equal(shellQuote("a b", "linux"), "'a b'");
+  assert.equal(shellQuote("it's", "darwin"), "'it'\"'\"'s'");
+  assert.equal(shellQuote("", "linux"), "''");
+});
+
+test("shellQuote uses cmd-style double quotes on Windows", () => {
+  assert.equal(shellQuote("", "win32"), '""');
+  assert.equal(shellQuote("simple/path", "win32"), "simple/path");
+  assert.equal(shellQuote("a b", "win32"), '"a b"');
+  assert.equal(shellQuote('say "hi"', "win32"), '"say ""hi"""');
+  assert.equal(shellQuote("*.py", "win32"), '"*.py"');
+  assert.equal(shellQuote("%TEMP%", "win32"), '"%TEMP%"');
+  assert.equal(shellQuote("^escape", "win32"), '"^escape"');
+  // Trailing backslash before closing " is a known ShellLexer/StripQuotes limitation
+  // outside this function's scope; do not use MSVC list2cmdline escaping here.
 });
 
 test("buildReadCommand uses cat by default and sed for line slices", () => {


### PR DESCRIPTION
## Summary
- Make `shellQuote` platform-aware via injectable `platformName` (defaults to `platform()` from `node:os`), mirroring the `rewrite-client.ts` pattern.
- On Windows: empty string → `""`, unsafe values wrapped in double quotes with embedded `"` doubled (`""`). Excludes cmd metacharacters `^` and `%` from the unquoted safe-path.
- On POSIX: behavior unchanged (single quotes); existing tests inject `"linux"`/`"darwin"` so they stay host-stable.
- Fix `.map(shellQuote)` call sites to `.map((a) => shellQuote(a))` so the new second parameter is not fed the array index.
- Document known Hypa-runtime limitations (cmd `%VAR%` expansion, trailing `\`, newlines) that require ShellLexer/StripQuotes work beyond this issue.

## Test plan
- [x] `cd packages/pi-hypa && npm test` (53/53 pass)
- [x] Windows-focused unit tests with `platformName: "win32"`: empty, safe path, spaces, embedded `"`, `*.py`, `%TEMP%`, `^escape`
- [x] POSIX tests with injected `"linux"`/`"darwin"`

Closes #56