### PR TITLE
Apply hypa_find limit in-process without head pipelines

### DIFF
--- a/packages/pi-hypa/extensions/tools.ts
+++ b/packages/pi-hypa/extensions/tools.ts
@@ -198,11 +198,25 @@ export function buildGrepCommand(params: {
   return args.map((a) => shellQuote(a)).join(" ");
 }
 
+/**
+ * Build a pure `rg --files` command (no shell pipelines).
+ * `limit` is accepted for call-site stability but ignored here — apply
+ * {@link limitStdoutLines} to the captured stdout in the tool execute handler.
+ * Piping to `head` forced shell invocation and is fragile on bare Windows.
+ */
 export function buildFindCommand(params: { pattern?: string; path?: string; limit?: number }): string {
+  void params.limit;
   const args = ["rg", "--files", "--glob", params.pattern ?? "*", normalizePathArg(params.path ?? ".")];
-  const base = args.map(shellQuote).join(" ");
-  if (params.limit === undefined) return base;
-  return `${base} | head -n ${shellQuote(String(Math.max(1, Math.floor(params.limit))))}`;
+  // Explicit arrow: shellQuote's second param is platformName, not Array.map's index
+  return args.map((a) => shellQuote(a)).join(" ");
+}
+
+/** Keep first N non-empty lines of path listing output (cross-platform limit). */
+export function limitStdoutLines(stdout: string, limit?: number): string {
+  if (limit === undefined) return stdout;
+  const max = Math.max(1, Math.floor(limit));
+  const lines = stdout.split(/\r?\n/).filter((line) => line.length > 0);
+  return lines.slice(0, max).join("\n") + (lines.length > 0 ? "\n" : "");
 }
 
 export function buildLsCommand(params: { path?: string; all?: boolean; long?: boolean }): string {
@@ -441,7 +455,11 @@ export function registerHypaTools(pi: PiApi, config: HypaPiConfig) {
     async execute(_toolCallId, params, signal, _onUpdate, _ctx) {
       const command = buildFindCommand(params);
       const result = await runHypaCommand(pi, config, command, params.timeoutMs, false, signal);
-      return toToolText(result, command);
+      const limited = {
+        ...result,
+        stdout: limitStdoutLines(result.stdout, params.limit),
+      };
+      return toToolText(limited, command);
     },
     renderCall(args: any, theme: any) {
       return renderHypaFindCall(args ?? {}, theme);

--- a/packages/pi-hypa/test/tools.test.ts
+++ b/packages/pi-hypa/test/tools.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { buildFindCommand, buildGrepCommand, buildLsCommand, buildReadCommand, shellQuote } from "../extensions/tools.js";
+import { buildFindCommand, buildGrepCommand, buildLsCommand, buildReadCommand, limitStdoutLines, shellQuote } from "../extensions/tools.js";
 
 test("shellQuote protects spaces and single quotes on POSIX", () => {
   assert.equal(shellQuote("simple/path", "linux"), "simple/path");
@@ -48,8 +48,38 @@ test("buildFindCommand lists files with ripgrep", () => {
   assert.equal(buildFindCommand({ pattern: "*.cs", path: "src" }), "rg --files --glob '*.cs' src");
 });
 
-test("buildFindCommand applies optional limit", () => {
-  assert.equal(buildFindCommand({ pattern: "*.cs", path: "src", limit: 10 }), "rg --files --glob '*.cs' src | head -n 10");
+test("buildFindCommand ignores limit and never pipes to head", () => {
+  const unlimited = buildFindCommand({ pattern: "*.cs", path: "src" });
+  const limited = buildFindCommand({ pattern: "*.cs", path: "src", limit: 10 });
+  assert.equal(limited, unlimited);
+  assert.equal(limited, "rg --files --glob '*.cs' src");
+  assert.doesNotMatch(limited, /\|/);
+  assert.doesNotMatch(limited, /\bhead\b/);
+});
+
+test("limitStdoutLines returns stdout unchanged when limit is undefined", () => {
+  assert.equal(limitStdoutLines(""), "");
+  assert.equal(limitStdoutLines("a\nb\n"), "a\nb\n");
+  assert.equal(limitStdoutLines("a\nb\n", undefined), "a\nb\n");
+});
+test("limitStdoutLines keeps first N non-empty lines", () => {
+  assert.equal(limitStdoutLines("", 5), "");
+  assert.equal(limitStdoutLines("a\nb\n", 5), "a\nb\n");
+  assert.equal(limitStdoutLines("a\nb\nc\nd\n", 2), "a\nb\n");
+  assert.equal(limitStdoutLines("only\n", 1), "only\n");
+});
+
+test("limitStdoutLines handles CRLF and empty lines", () => {
+  assert.equal(limitStdoutLines("a\r\nb\r\nc\r\n", 2), "a\nb\n");
+  // empty lines are skipped when counting paths
+  assert.equal(limitStdoutLines("a\n\nb\n\nc\n", 2), "a\nb\n");
+  assert.equal(limitStdoutLines("\n\n", 3), "");
+});
+
+test("limitStdoutLines floors and clamps limit to at least 1", () => {
+  assert.equal(limitStdoutLines("a\nb\nc\n", 2.9), "a\nb\n");
+  assert.equal(limitStdoutLines("a\nb\n", 0), "a\n");
+  assert.equal(limitStdoutLines("a\nb\n", -3), "a\n");
 });
 
 test("buildLsCommand defaults to long listing", () => {


### PR DESCRIPTION
## Summary

Follow-up to PR #60 / #61 review residual: `hypa_find` with `limit` still broke on Windows.

- **Never pipe to `head`.** `buildFindCommand` always emits a pure `rg --files ...` command (no shell metacharacters that force shell/`cmd.exe` invocation when avoidable).
- **Apply limit in-process** via new `limitStdoutLines(stdout, limit?)` after capturing `rg --files` output in the `hypa_find` execute handler.
- **Fix `args.map(shellQuote)` → `args.map((a) => shellQuote(a))`.** `Array.map` was passing the index as `shellQuote`'s `platformName`, so Windows quoting never applied (grep/ls were fixed in #61; find was not).
- `limit` remains optional on `buildFindCommand` for call-site stability but is ignored when building the shell string (documented).

## Test plan

- [x] `cd packages/pi-hypa && npm test` — 59 pass
- [x] `npm run build` (`tsc --noEmit`)
- [x] Assert limited/unlimited `buildFindCommand` produce the same string (no `|` / `head`)
- [x] Unit tests for `limitStdoutLines`: empty, under/over limit, CRLF, empty lines, floor/clamp

## Context

PR #60 switched find to ripgrep; PR #61 fixed Windows `shellQuote`. Review on #60 noted that piping to `head` remains fragile on bare Windows and that find still had the `.map(shellQuote)` index bug. This PR addresses that residual.