### PR TITLE
Run Hypa via native binary under Pi with Bun

### DIFF
--- a/packages/pi-hypa/README.md
+++ b/packages/pi-hypa/README.md
@@ -21,7 +21,7 @@ Hypa is not an LLM summarizer. The default reduction path is local, deterministi
 
 ## What this extension adds
 
-Installing this package through Pi also installs `@hypabolic/hypa` as a package dependency and creates a best-effort user-level `hypa` shim when no `hypa` command is already on `PATH`. The shim delegates to a later global/system `hypa` install if one appears earlier on `PATH`, and otherwise falls back to the bundled dependency.
+Installing this package through Pi also installs `@hypabolic/hypa` as a package dependency and creates a best-effort user-level `hypa` shim when no `hypa` command is already on `PATH`. The shim delegates to a later global/system `hypa` install if one appears earlier on `PATH`, and otherwise falls back to the platform-native binary from optional deps (or `bin.js` via the install-time JS runtime when the native package is unavailable).
 
 The extension provides:
 
@@ -45,8 +45,10 @@ pi install npm:@hypabolic/pi-hypa
 ### Requirements
 
 - Pi with the `@earendil-works/pi-coding-agent` peer dependency.
-- Node.js 18 or newer.
+- Node.js 18 or newer, **or Bun** (Pi with `"npmCommand": ["bun"]` works without Node on `PATH`).
 - Linux, macOS, or Windows on x64 or arm64 (the bundled `@hypabolic/hypa` selects the matching native binary).
+
+Hypa is invoked via the platform-native binary whenever it is installed as an optional dependency. Node is not required at runtime for the extension when that native binary is available. If only the `bin.js` launcher is present, the extension runs it with the host JS runtime (`process.execPath` — bun under Bun, node under Node) instead of hardcoding `node`.
 
 ## Configuration
 

--- a/packages/pi-hypa/extensions/rewrite-client.ts
+++ b/packages/pi-hypa/extensions/rewrite-client.ts
@@ -9,39 +9,96 @@ import { isHypaCommand, mapRewriteResult, parseRewriteJson } from "./policy.js";
 /**
  * Normalises a resolved binary path + its arguments for the current platform.
  *
- * On Windows, Node.js cannot `spawn` a `.js` file directly (no shebang support)
- * or a `.cmd` shell script without a shell — both produce `EFTYPE`. Wrap them
- * with the appropriate interpreter so `pi.exec` always receives a native binary.
+ * Node.js cannot `spawn` a `.js` file without an interpreter on Windows (no
+ * shebang support). On Unix the shebang is typically `#!/usr/bin/env node`,
+ * which fails when only Bun is installed. Always wrap `.js` entrypoints with
+ * the current host runtime (`process.execPath`) so Pi under Bun uses bun and
+ * Node hosts use node.
+ *
+ * On Windows, `.cmd` / `.bat` shims also need `cmd /c` to avoid `EFTYPE`.
  */
 export function getExecArgs(
   binary: string,
   args: string[],
   platformName: string = platform(),
+  jsRuntime: string = process.execPath,
 ): [string, string[]] {
-  if (platformName !== "win32") return [binary, args];
-
   const lower = binary.toLowerCase();
-  if (lower.endsWith(".js")) return ["node", [binary, ...args]];
-  if (lower.endsWith(".cmd") || lower.endsWith(".bat")) return ["cmd", ["/c", binary, ...args]];
-
+  if (lower.endsWith(".js")) return [jsRuntime, [binary, ...args]];
+  if (platformName === "win32" && (lower.endsWith(".cmd") || lower.endsWith(".bat"))) {
+    return ["cmd", ["/c", binary, ...args]];
+  }
   return [binary, args];
 }
 
 const require = createRequire(import.meta.url);
 
+/** Platform package keys matching npm/hypa/bin.js PLATFORM_MAP. */
+const PLATFORM_MAP: Record<string, Record<string, string>> = {
+  linux: { x64: "linux-x64", arm64: "linux-arm64" },
+  darwin: { x64: "darwin-x64", arm64: "darwin-arm64" },
+  win32: { x64: "win32-x64", arm64: "win32-arm64" },
+};
+
+type RequireResolve = (id: string) => string;
+
+function isJsEntry(path: string): boolean {
+  return /\.js$/i.test(path);
+}
+
+/**
+ * Resolve the platform-native hypa binary from optional deps
+ * (`@hypabolic/hypa-{linux,darwin,win32}-{x64,arm64}`).
+ */
+export function resolveNativeHypaBinary(
+  exists: (p: string) => boolean = existsSync,
+  requireResolve: RequireResolve = require.resolve.bind(require),
+  platformName: string = platform(),
+  archName: string = process.arch,
+): string | undefined {
+  const archKey = PLATFORM_MAP[platformName]?.[archName];
+  if (!archKey) return undefined;
+
+  const pkgName = `@hypabolic/hypa-${archKey}`;
+  try {
+    const packageJson = requireResolve(`${pkgName}/package.json`);
+    const packageRoot = dirname(packageJson);
+    const binaryName = platformName === "win32" ? "hypa.exe" : "hypa";
+    const binaryPath = join(packageRoot, "bin", binaryName);
+    return exists(binaryPath) ? binaryPath : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve order for bare names like `hypa`:
+ * 1. Absolute/relative path in binary name → return as-is (caller intent).
+ * 2. PATH candidate that is not a JS entry → return it (real native/shell shim).
+ * 3. Native bundled binary if present.
+ * 4. PATH JS candidate if any.
+ * 5. bin.js fallback.
+ * 6. bare name.
+ */
 export function resolveHypaBinary(
   binary: string,
   env: NodeJS.ProcessEnv = process.env,
   platformName: string = platform(),
   exists: (p: string) => boolean = existsSync,
+  requireResolve: RequireResolve = require.resolve.bind(require),
 ): string {
   if (binary.includes("/") || binary.includes("\\")) return binary;
 
   const pathBinary = resolvePathBinary(binary, env, platformName, exists);
+  if (pathBinary && !isJsEntry(pathBinary)) return pathBinary;
+
+  const nativeBinary = resolveNativeHypaBinary(exists, requireResolve, platformName);
+  if (nativeBinary) return nativeBinary;
+
   if (pathBinary) return pathBinary;
 
-  const bundledBinary = resolveBundledHypaBinary(binary, exists);
-  if (bundledBinary) return bundledBinary;
+  const jsBundled = resolveBundledJsHypaBinary(binary, exists, requireResolve);
+  if (jsBundled) return jsBundled;
 
   return binary;
 }
@@ -111,11 +168,30 @@ function getWindowsExecutableExtensions(env: NodeJS.ProcessEnv): string[] {
   return extensions;
 }
 
-function resolveBundledHypaBinary(binary: string, exists: (p: string) => boolean): string | undefined {
+/** Prefer native optional-dep binary; fall back to @hypabolic/hypa/bin.js. */
+export function resolveBundledHypaBinary(
+  binary: string,
+  exists: (p: string) => boolean = existsSync,
+  requireResolve: RequireResolve = require.resolve.bind(require),
+  platformName: string = platform(),
+): string | undefined {
+  if (binary !== "hypa") return undefined;
+
+  const native = resolveNativeHypaBinary(exists, requireResolve, platformName);
+  if (native) return native;
+
+  return resolveBundledJsHypaBinary(binary, exists, requireResolve);
+}
+
+function resolveBundledJsHypaBinary(
+  binary: string,
+  exists: (p: string) => boolean,
+  requireResolve: RequireResolve,
+): string | undefined {
   if (binary !== "hypa") return undefined;
 
   try {
-    const packageJson = require.resolve("@hypabolic/hypa/package.json");
+    const packageJson = requireResolve("@hypabolic/hypa/package.json");
     const packageRoot = dirname(packageJson);
     const bin = join(packageRoot, "bin.js");
     return exists(bin) ? bin : undefined;

--- a/packages/pi-hypa/scripts/postinstall.js
+++ b/packages/pi-hypa/scripts/postinstall.js
@@ -8,6 +8,13 @@ import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
+/** Platform package keys matching npm/hypa/bin.js PLATFORM_MAP. */
+const PLATFORM_MAP = {
+  linux: { x64: "linux-x64", arm64: "linux-arm64" },
+  darwin: { x64: "darwin-x64", arm64: "darwin-arm64" },
+  win32: { x64: "win32-x64", arm64: "win32-arm64" },
+};
+
 function isLocalDevelopmentInstall() {
   if (process.env.CI) return true;
   if (!process.env.INIT_CWD) return false;
@@ -43,10 +50,42 @@ function commandExists(command) {
   return false;
 }
 
-function resolveBundledHypaBin() {
+function resolveNativeHypaBinary() {
+  const archKey = PLATFORM_MAP[platform()]?.[process.arch];
+  if (!archKey) return undefined;
+
+  const pkgName = `@hypabolic/hypa-${archKey}`;
+  try {
+    const packageJson = require.resolve(`${pkgName}/package.json`);
+    const packageRoot = dirname(packageJson);
+    const binaryName = platform() === "win32" ? "hypa.exe" : "hypa";
+    const binaryPath = join(packageRoot, "bin", binaryName);
+    return existsSync(binaryPath) ? binaryPath : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveBundledJsHypaBin() {
   const hypaPackageJson = require.resolve("@hypabolic/hypa/package.json");
   const hypaPackageRoot = dirname(hypaPackageJson);
   return join(hypaPackageRoot, "bin.js");
+}
+
+/**
+ * Prefer the platform-native binary; fall back to bin.js + current JS runtime.
+ * Returns { kind: "native", path } | { kind: "js", path, runtime }.
+ */
+function resolveShimTarget() {
+  const native = resolveNativeHypaBinary();
+  if (native) return { kind: "native", path: native };
+
+  return {
+    kind: "js",
+    path: resolveBundledJsHypaBin(),
+    // Use the host that ran postinstall (bun or node), not a hardcoded "node".
+    runtime: process.execPath,
+  };
 }
 
 function quoteSh(value) {
@@ -62,6 +101,11 @@ function installUnixShim(target) {
     console.error(`[pi-hypa] Hypa shim already exists at ${shim}; leaving it unchanged.`);
     return;
   }
+
+  const fallback =
+    target.kind === "native"
+      ? `exec ${quoteSh(target.path)} "$@"`
+      : `exec ${quoteSh(target.runtime)} ${quoteSh(target.path)} "$@"`;
 
   const script = `#!/usr/bin/env sh
 set -eu
@@ -79,7 +123,7 @@ for dir in $PATH; do
   fi
 done
 IFS="$OLD_IFS"
-exec node ${quoteSh(target)} "$@"
+${fallback}
 `;
 
   writeFileSync(shim, script, { mode: 0o755 });
@@ -101,6 +145,11 @@ function installWindowsShim(target) {
     return;
   }
 
+  const fallback =
+    target.kind === "native"
+      ? `"${target.path}" %*`
+      : `"${target.runtime}" "${target.path}" %*`;
+
   const script = `@echo off
 setlocal enabledelayedexpansion
 set "SELF=%~f0"
@@ -118,7 +167,7 @@ for %%D in ("%PATH:;=" "%") do (
     )
   )
 )
-node "${target}" %*
+${fallback}
 `;
 
   writeFileSync(shim, script);
@@ -133,9 +182,9 @@ try {
     process.exit(0);
   }
 
-  const bundledHypa = resolveBundledHypaBin();
-  if (platform() === "win32") installWindowsShim(bundledHypa);
-  else installUnixShim(bundledHypa);
+  const target = resolveShimTarget();
+  if (platform() === "win32") installWindowsShim(target);
+  else installUnixShim(target);
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
   console.error(`[pi-hypa] Could not install Hypa CLI shim: ${message}`);

--- a/packages/pi-hypa/test/rewrite-client.test.ts
+++ b/packages/pi-hypa/test/rewrite-client.test.ts
@@ -2,7 +2,13 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { win32 } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { resolveHypaBinary, rewriteCommand, getExecArgs } from "../extensions/rewrite-client.js";
+import {
+  resolveHypaBinary,
+  resolveNativeHypaBinary,
+  resolveBundledHypaBinary,
+  rewriteCommand,
+  getExecArgs,
+} from "../extensions/rewrite-client.js";
 import type { HypaPiConfig } from "../extensions/types.js";
 
 const config: HypaPiConfig = {
@@ -32,7 +38,100 @@ function fakeExists(paths: string[]) {
 
 test("resolveHypaBinary falls back to bundled dependency when PATH is empty", () => {
   const resolved = resolveHypaBinary("hypa", { PATH: "" });
-  assert.match(resolved, /@hypabolic\/hypa|node_modules\/\.pnpm\/.*@hypabolic\+hypa/);
+  // Prefer native platform package when installed; otherwise bin.js.
+  assert.match(
+    resolved,
+    /@hypabolic\/hypa|node_modules\/\.pnpm\/.*@hypabolic\+hypa|hypa-(linux|darwin|win32)-(x64|arm64)/,
+  );
+});
+
+test("resolveNativeHypaBinary returns platform package binary when present", () => {
+  const resolved = resolveNativeHypaBinary();
+  // Optional platform dep is usually installed via @hypabolic/hypa; skip if missing.
+  if (resolved === undefined) return;
+  assert.match(resolved, /hypa-(linux|darwin|win32)-(x64|arm64)/);
+  assert.match(resolved, /[\\/]bin[\\/]hypa(\.exe)?$/);
+});
+
+test("resolveBundledHypaBinary prefers native over bin.js when both exist", () => {
+  const nativePath = "/fake/node_modules/@hypabolic/hypa-linux-x64/bin/hypa";
+  const jsPath = "/fake/node_modules/@hypabolic/hypa/bin.js";
+  const exists = fakeExists([nativePath, jsPath]);
+  const requireResolve = (id: string) => {
+    if (id === "@hypabolic/hypa-linux-x64/package.json") {
+      return "/fake/node_modules/@hypabolic/hypa-linux-x64/package.json";
+    }
+    if (id === "@hypabolic/hypa/package.json") {
+      return "/fake/node_modules/@hypabolic/hypa/package.json";
+    }
+    throw new Error(`unexpected resolve: ${id}`);
+  };
+
+  const resolved = resolveBundledHypaBinary("hypa", exists, requireResolve, "linux");
+  assert.equal(resolved, nativePath);
+});
+
+test("resolveBundledHypaBinary falls back to bin.js when native is missing", () => {
+  const jsPath = "/fake/node_modules/@hypabolic/hypa/bin.js";
+  const exists = fakeExists([jsPath]);
+  const requireResolve = (id: string) => {
+    if (id.startsWith("@hypabolic/hypa-")) {
+      throw new Error("native package not installed");
+    }
+    if (id === "@hypabolic/hypa/package.json") {
+      return "/fake/node_modules/@hypabolic/hypa/package.json";
+    }
+    throw new Error(`unexpected resolve: ${id}`);
+  };
+
+  const resolved = resolveBundledHypaBinary("hypa", exists, requireResolve, "linux");
+  assert.equal(resolved, jsPath);
+});
+
+test("resolveHypaBinary prefers real PATH native binary over bundled native", () => {
+  const binDir = "/usr/local/bin";
+  const pathHypa = "/usr/local/bin/hypa";
+  const nativePath = "/fake/node_modules/@hypabolic/hypa-linux-x64/bin/hypa";
+  const exists = fakeExists([pathHypa, nativePath]);
+  const requireResolve = (id: string) => {
+    if (id === "@hypabolic/hypa-linux-x64/package.json") {
+      return "/fake/node_modules/@hypabolic/hypa-linux-x64/package.json";
+    }
+    throw new Error(`unexpected resolve: ${id}`);
+  };
+
+  const resolved = resolveHypaBinary("hypa", { PATH: binDir }, "linux", exists, requireResolve);
+  assert.equal(resolved, pathHypa);
+});
+
+test("resolveHypaBinary prefers native over PATH JS entry when PATH hits a .js launcher", () => {
+  // PATH can surface a .js entry (e.g. hypa.js or a bin.js-style launcher name).
+  // Prefer the platform-native binary so Bun hosts never need node.
+  const pathJsDir = "/opt/x";
+  const pathJs = "/opt/x/hypa.js";
+  const nativePath = "/fake/node_modules/@hypabolic/hypa-linux-x64/bin/hypa";
+  const exists = fakeExists([pathJs, nativePath]);
+  const requireResolve = (id: string) => {
+    if (id === "@hypabolic/hypa-linux-x64/package.json") {
+      return "/fake/node_modules/@hypabolic/hypa-linux-x64/package.json";
+    }
+    throw new Error(`unexpected resolve: ${id}`);
+  };
+
+  const resolved = resolveHypaBinary("hypa.js", { PATH: pathJsDir }, "linux", exists, requireResolve);
+  assert.equal(resolved, nativePath);
+});
+
+test("resolveHypaBinary returns PATH JS entry when native is unavailable", () => {
+  const pathJsDir = "/opt/x";
+  const pathJs = "/opt/x/hypa.js";
+  const exists = fakeExists([pathJs]);
+  const requireResolve = (_id: string) => {
+    throw new Error("native package not installed");
+  };
+
+  const resolved = resolveHypaBinary("hypa.js", { PATH: pathJsDir }, "linux", exists, requireResolve);
+  assert.equal(resolved, pathJs);
 });
 
 test("resolveHypaBinary prefers Windows .cmd over extension-less npm shim", () => {
@@ -123,10 +222,24 @@ test("rewriteCommand fails safe on timeout", async () => {
   assert.match(status.kind === "error" ? status.error : "", /timed out/);
 });
 
-test("getExecArgs wraps Windows .js binaries with node", () => {
-  assert.deepEqual(getExecArgs("/path/to/bin.js", ["-c", "echo hi"], "win32"), [
-    "node",
+test("getExecArgs wraps .js binaries with process.execPath on win32", () => {
+  assert.deepEqual(getExecArgs("/path/to/bin.js", ["-c", "echo hi"], "win32", process.execPath), [
+    process.execPath,
     ["/path/to/bin.js", "-c", "echo hi"],
+  ]);
+});
+
+test("getExecArgs wraps .js binaries with injected bun runtime on win32", () => {
+  assert.deepEqual(getExecArgs("/path/to/bin.js", ["arg"], "win32", "/usr/local/bin/bun"), [
+    "/usr/local/bin/bun",
+    ["/path/to/bin.js", "arg"],
+  ]);
+});
+
+test("getExecArgs wraps .js binaries with injected bun runtime on linux", () => {
+  assert.deepEqual(getExecArgs("/path/bin.js", ["arg"], "linux", "/usr/local/bin/bun"), [
+    "/usr/local/bin/bun",
+    ["/path/bin.js", "arg"],
   ]);
 });
 
@@ -138,16 +251,22 @@ test("getExecArgs passes through Windows .exe binaries", () => {
   assert.deepEqual(getExecArgs("hypa.exe", ["arg"], "win32"), ["hypa.exe", ["arg"]]);
 });
 
-test("getExecArgs passes through non-Windows .js binaries", () => {
-  assert.deepEqual(getExecArgs("/path/bin.js", ["arg"], "linux"), ["/path/bin.js", ["arg"]]);
+test("getExecArgs wraps non-Windows .js binaries with jsRuntime", () => {
+  assert.deepEqual(getExecArgs("/path/bin.js", ["arg"], "linux", process.execPath), [
+    process.execPath,
+    ["/path/bin.js", "arg"],
+  ]);
 });
 
 test("getExecArgs wraps Windows .bat binaries with cmd", () => {
   assert.deepEqual(getExecArgs("C:\\hypa.bat", ["arg"], "win32"), ["cmd", ["/c", "C:\\hypa.bat", "arg"]]);
 });
 
-test("getExecArgs wraps Windows uppercase .JS binaries with node", () => {
-  assert.deepEqual(getExecArgs("/path/to/bin.JS", ["arg"], "win32"), ["node", ["/path/to/bin.JS", "arg"]]);
+test("getExecArgs wraps Windows uppercase .JS binaries with jsRuntime", () => {
+  assert.deepEqual(getExecArgs("/path/to/bin.JS", ["arg"], "win32", process.execPath), [
+    process.execPath,
+    ["/path/to/bin.JS", "arg"],
+  ]);
 });
 
 test("getExecArgs wraps Windows uppercase .CMD binaries with cmd", () => {


### PR DESCRIPTION
Closes #63

## Summary
- Prefer platform-native hypa binary over `bin.js` (avoids `#!/usr/bin/env node`)
- `getExecArgs` uses `process.execPath` for `.js` entrypoints on all platforms (works under Bun)
- postinstall shim no longer hardcodes `node` — uses native binary or install-time `process.execPath`

## Root cause
`@hypabolic/pi-hypa` resolved/ran Hypa through Node-dependent entry points (`bin.js` shebang, hardcoded `node` in `getExecArgs` and the user shim). With Pi configured as `"npmCommand": ["bun"]` and no Node on PATH, spawns failed with `node: command not found`.

## Test plan
- [x] `packages/pi-hypa` npm test (67 pass)
- [x] `packages/pi-hypa` npm run build
- [ ] CI green