### PR TITLE
Fix tilde (~) not expanding in hypa -c for unquoted args

### DIFF
--- a/src/Hypa.Cli/Commands/RunCommand.cs
+++ b/src/Hypa.Cli/Commands/RunCommand.cs
@@ -86,6 +86,7 @@ public sealed class RunCommand(CommandRunnerService runnerService, IShellLexer s
         var usesShellSyntax =
             lexed.Any(t => t.Kind is TokenKind.Operator or TokenKind.Pipe or TokenKind.Redirect or TokenKind.Shellism)
             || ShellExpansion.ContainsExpansion(lexed)
+            || ShellExpansion.ContainsTildeExpansion(lexed)
             || ShellVerb.HasAssignmentPrefix(lexed)
             || (verb is not null && ShellBuiltins.IsStateful(verb));
 

--- a/src/Hypa.Runtime/Domain/Rewrite/ShellExpansion.cs
+++ b/src/Hypa.Runtime/Domain/Rewrite/ShellExpansion.cs
@@ -10,4 +10,19 @@ public static class ShellExpansion
         tokens.Any(token =>
             token.Kind is TokenKind.Arg or TokenKind.QuotedArg &&
             (token.Value.Contains('$') || token.Value.Contains('`')));
+
+    /// <summary>
+    /// Detects unquoted argument tokens that begin with a tilde, such as
+    /// <c>~/x</c>, <c>~</c>, or <c>~user/bin</c>. Tilde expansion is performed
+    /// by the shell and only at the start of an unquoted word; running the
+    /// program directly would pass the literal text through as an argument, so
+    /// such commands must route through <c>sh -c</c>. A tilde inside quotes
+    /// (<c>"~/x"</c>) is intentionally not expanded by POSIX shells and stays
+    /// on the direct-execution path, as does a tilde that is not at the start
+    /// of a token (e.g. <c>a~b</c>).
+    /// </summary>
+    public static bool ContainsTildeExpansion(IReadOnlyList<ShellToken> tokens) =>
+        tokens.Any(token =>
+            token.Kind is TokenKind.Arg &&
+            token.Value.StartsWith('~'));
 }

--- a/tests/Hypa.UnitTests/Cli/RunCommandTests.cs
+++ b/tests/Hypa.UnitTests/Cli/RunCommandTests.cs
@@ -183,6 +183,80 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public async Task BufferedTildeArg_UsesShellInvocation()
+    {
+        var command = "echo ~/Desktop";
+        var (root, runner) = BuildRoot();
+        CommandInvocation? invocation = null;
+        runner.RunAsync(Arg.Do<CommandInvocation>(i => invocation = i), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("ok", "", 0, TimeSpan.Zero)));
+
+        var exitCode = await root.InvokeAsync(["-c", command]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(invocation);
+        Assert.Equal(ExpectedShell, invocation.Executable);
+        Assert.Equal(ExpectedShellArgs(command), invocation.Arguments);
+    }
+
+    [Fact]
+    public async Task BufferedBareTilde_UsesShellInvocation()
+    {
+        var command = "echo ~";
+        var (root, runner) = BuildRoot();
+        CommandInvocation? invocation = null;
+        runner.RunAsync(Arg.Do<CommandInvocation>(i => invocation = i), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("ok", "", 0, TimeSpan.Zero)));
+
+        var exitCode = await root.InvokeAsync(["-c", command]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(invocation);
+        Assert.Equal(ExpectedShell, invocation.Executable);
+        Assert.Equal(ExpectedShellArgs(command), invocation.Arguments);
+    }
+
+    [Fact]
+    public async Task BufferedDoubleQuotedTilde_UsesDirectInvocation()
+    {
+        // A tilde inside double quotes is not expanded by POSIX shells, so the
+        // direct-execution path is correct and must be preserved.
+        var command = "echo \"~/Desktop\"";
+        var (root, runner) = BuildRoot();
+        CommandInvocation? invocation = null;
+        runner.RunAsync(Arg.Do<CommandInvocation>(i => invocation = i), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("ok", "", 0, TimeSpan.Zero)));
+
+        var exitCode = await root.InvokeAsync(["-c", command]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(invocation);
+        Assert.NotEqual(ExpectedShell, invocation.Executable);
+    }
+
+    [Fact]
+    public async Task BufferedTildeNotAtStart_UsesDirectInvocation()
+    {
+        // A tilde that is not at the start of an unquoted word is not expanded,
+        // so the direct-execution path is correct and must be preserved.
+        var command = "echo a~b";
+        var (root, runner) = BuildRoot();
+        CommandInvocation? invocation = null;
+        runner.RunAsync(Arg.Do<CommandInvocation>(i => invocation = i), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("ok", "", 0, TimeSpan.Zero)));
+
+        var exitCode = await root.InvokeAsync(["-c", command]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(invocation);
+        Assert.NotEqual(ExpectedShell, invocation.Executable);
+    }
+
+    [Fact]
     public async Task BufferedPlainCommand_UsesDirectInvocation()
     {
         var (root, runner) = BuildRoot();

--- a/tests/Hypa.UnitTests/Domain/ShellExpansionTests.cs
+++ b/tests/Hypa.UnitTests/Domain/ShellExpansionTests.cs
@@ -56,4 +56,82 @@ public sealed class ShellExpansionTests
 
         Assert.False(result);
     }
+
+    [Fact]
+    public void ContainsTildeExpansion_UnquotedLeadingTilde_ReturnsTrue()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "~/Desktop", 0),
+        };
+
+        var result = ShellExpansion.ContainsTildeExpansion(tokens);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ContainsTildeExpansion_BareTilde_ReturnsTrue()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "~", 0),
+        };
+
+        var result = ShellExpansion.ContainsTildeExpansion(tokens);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ContainsTildeExpansion_TildeUser_ReturnsTrue()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "~user/bin", 0),
+        };
+
+        var result = ShellExpansion.ContainsTildeExpansion(tokens);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ContainsTildeExpansion_QuotedTilde_ReturnsFalse()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.QuotedArg, "\"~/Desktop\"", 0),
+        };
+
+        var result = ShellExpansion.ContainsTildeExpansion(tokens);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ContainsTildeExpansion_TildeNotAtStart_ReturnsFalse()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "a~b", 0),
+        };
+
+        var result = ShellExpansion.ContainsTildeExpansion(tokens);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ContainsTildeExpansion_PlainArg_ReturnsFalse()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "plain", 0),
+        };
+
+        var result = ShellExpansion.ContainsTildeExpansion(tokens);
+
+        Assert.False(result);
+    }
 }


### PR DESCRIPTION
## Summary

`hypa -c` did not expand an unquoted leading tilde (`~`). An argument such as `~/Desktop` or `~` was lexed as a plain `Arg` token, so none of the existing `usesShellSyntax` triggers fired and the command ran via direct `Process.Start` - passing the literal text through as an argument without tilde expansion.

This is the same class of bug as #42 / #44 (variable/command-substitution not expanded inside quoted args), which #46 fixed by routing commands containing `$` or a backtick through the shell. That fix left tilde expansion uncovered.

## Reproduction (on 0.1.10 / main)

```bash
$ hypa -c 'echo ~/Desktop'
~/Desktop                      # literal, should be /Users/.../Desktop

$ hypa -c 'ls -d ~/Desktop'
ls: ~/Desktop: No such file or directory

$ hypa -c 'rm -rf ~/some/dir'  # -f swallows the error
$ echo $?                       # exit 0, but nothing was deleted
```

Whether `~` worked depended on the presence of an unrelated shell construct (pipe, `;`, `&&`, `$`, or `cd`), which routed the command through `sh -c` as a side effect - making the behaviour appear random.

## Root cause

`RunCommand.HandleBufferedAsync` decides between direct execution and `sh -c` via `usesShellSyntax`:

```csharp
var usesShellSyntax =
    lexed.Any(t => t.Kind is TokenKind.Operator or TokenKind.Pipe or TokenKind.Redirect or TokenKind.Shellism)
    || ShellExpansion.ContainsExpansion(lexed)        // $ / backtick only
    || ShellVerb.HasAssignmentPrefix(lexed)
    || (verb is not null && ShellBuiltins.IsStateful(verb));
```

`ShellLexer` does not treat `~` as special, so `~/Desktop` becomes a plain `Arg` and no trigger fires.

## Fix

Add `ShellExpansion.ContainsTildeExpansion`, which routes a command through the shell whenever an **unquoted** `Arg` token starts with `~`, and wire it into `usesShellSyntax`.

```csharp
public static bool ContainsTildeExpansion(IReadOnlyList<ShellToken> tokens) =>
    tokens.Any(token =>
        token.Kind is TokenKind.Arg &&
        token.Value.StartsWith('~'));
```

Only `TokenKind.Arg` (not `QuotedArg`) is considered, and only a leading `~`, matching POSIX: a tilde is expanded solely at the start of an unquoted word. Quoted tildes (`"~/x"`) and non-leading tildes (`a~b`) are intentionally left on the direct-execution path, where their (non-)expansion is already correct - so this does not regress those cases.

## Verification

- `dotnet build -c Release /p:TreatWarningsAsErrors=true` - 0 warnings, 0 errors
- `dotnet test` (ShellExpansion / RunCommand / ShellLexer) - 39 passed
- `dotnet format --verify-no-changes` - clean
- End-to-end against the built binary:

| Command | Before | After |
| --- | --- | --- |
| `echo ~/Desktop` | `~/Desktop` | `/Users/.../Desktop` |
| `echo ~` | `~` | `/Users/...` |
| `echo ~/Desktop \| cat` | `/Users/.../Desktop` | `/Users/.../Desktop` (no regression) |
| `echo "~/Desktop"` | `~/Desktop` | `~/Desktop` (quoted, not expanded - correct) |
| `echo a~b` | `a~b` | `a~b` (non-leading, not expanded - correct) |

Refs #42, #44, #46.
