### PR TITLE
Fix ~ not expanding in hypa_read/grep/find/ls path arguments

### DIFF
--- a/packages/pi-hypa/extensions/tools.ts
+++ b/packages/pi-hypa/extensions/tools.ts
@@ -1,5 +1,5 @@
 import { mkdtemp, writeFile } from "node:fs/promises";
-import { platform, tmpdir } from "node:os";
+import { homedir, platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import { Text } from "@earendil-works/pi-tui";
 import type { HypaPiConfig } from "./types.js";
@@ -164,7 +164,16 @@ export function shellQuote(value: string, platformName: NodeJS.Platform = platfo
 }
 
 function normalizePathArg(path: string): string {
-  return path.startsWith("@") ? path.slice(1) : path;
+  // A leading "@" is an artifact of pi's file-mention syntax; strip it first.
+  const unprefixed = path.startsWith("@") ? path.slice(1) : path;
+  // Expand a leading "~" to the home directory, mirroring pi's native file
+  // tools, so the path reaches the Hypa CLI already absolute. Without this the
+  // tilde is passed through literally and then single-quoted by shellQuote, so
+  // neither the CLI nor a shell ever expands it. "~user/..." is intentionally
+  // left untouched (it needs the OS user database).
+  if (unprefixed === "~") return homedir();
+  if (unprefixed.startsWith("~/")) return homedir() + unprefixed.slice(1);
+  return unprefixed;
 }
 
 export function buildReadCommand(path: string, offset?: number, limit?: number): string {

--- a/packages/pi-hypa/test/tools.test.ts
+++ b/packages/pi-hypa/test/tools.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { homedir } from "node:os";
 import { buildFindCommand, buildGrepCommand, buildLsCommand, buildReadCommand, limitStdoutLines, shellQuote } from "../extensions/tools.js";
 
 test("shellQuote protects spaces and single quotes on POSIX", () => {
@@ -80,6 +81,33 @@ test("limitStdoutLines floors and clamps limit to at least 1", () => {
   assert.equal(limitStdoutLines("a\nb\nc\n", 2.9), "a\nb\n");
   assert.equal(limitStdoutLines("a\nb\n", 0), "a\n");
   assert.equal(limitStdoutLines("a\nb\n", -3), "a\n");
+});
+
+test("normalizePathArg expands a leading ~ to the home directory", () => {
+  const home = homedir();
+  assert.equal(buildReadCommand("~/notes.txt"), `cat -- ${shellQuote(`${home}/notes.txt`)}`);
+  assert.equal(buildReadCommand("~"), `cat -- ${shellQuote(home)}`);
+  assert.equal(buildLsCommand({ path: "~" }), `ls -l -- ${shellQuote(home)}`);
+  assert.equal(
+    buildGrepCommand({ pattern: "needle", path: "~/src" }),
+    `rg --heading --line-number --color=never -e needle -- ${shellQuote(`${home}/src`)}`,
+  );
+  assert.equal(
+    buildFindCommand({ pattern: "*.ts", path: "~/src" }),
+    `rg --files --glob '*.ts' ${shellQuote(`${home}/src`)}`,
+  );
+});
+
+test("normalizePathArg strips a leading @ before expanding ~ (pi file-mention syntax)", () => {
+  const home = homedir();
+  assert.equal(buildReadCommand("@~/notes.txt"), `cat -- ${shellQuote(`${home}/notes.txt`)}`);
+  assert.equal(buildReadCommand("@/etc/hosts"), "cat -- /etc/hosts");
+});
+
+test("normalizePathArg leaves ~user, absolute, and relative paths untouched", () => {
+  assert.equal(buildReadCommand("~otheruser/file"), "cat -- '~otheruser/file'");
+  assert.equal(buildReadCommand("/etc/hosts"), "cat -- /etc/hosts");
+  assert.equal(buildReadCommand("./rel"), "cat -- ./rel");
 });
 
 test("buildLsCommand defaults to long listing", () => {


### PR DESCRIPTION
## Summary

`hypa_read`, `hypa_grep`, `hypa_find` and `hypa_ls` don't expand a leading `~`
in their `path` argument, so any home-relative path fails. `normalizePathArg`
only strips a leading `@` today; this PR also expands `~` / `~/…` to the home
directory (mirroring pi's native file tools), so the path reaches the Hypa CLI
already absolute.

## The problem

pi's native `read`/`grep`/`find`/`ls` expand `~` (via `resolveToCwd` →
`normalizePath(..., { expandTilde: true })`), so users and models reasonably
expect the `hypa_*` equivalents to behave the same. They don't:

```
# hypa_read  path = "~/.bashrc"   →   buildReadCommand emits:
cat -- '~/.bashrc'

$ hypa -c "cat -- '~/.bashrc'"
cat: '~/.bashrc': No such file or directory       # ❌ tilde passed literally
```

Same failure on `hypa_grep`/`hypa_find`/`hypa_ls` with a `~/…` path, and on the
`@~/…` file-mention form. Reproduced on `0.1.10`.

## Root cause

`normalizePathArg` (packages/pi-hypa/extensions/tools.ts) is the only place the
structured-tool path is normalized before it's handed to `shellQuote` and run:

```ts
function normalizePathArg(path: string): string {
  return path.startsWith("@") ? path.slice(1) : path;
}
```

It never expands `~`. Worse, `~` is **not** in `POSIX_SAFE_VALUE`, so
`shellQuote` wraps the path in single quotes (`'~/.bashrc'`). A single-quoted
tilde is literal even in a POSIX shell — so this can't be fixed downstream in the
.NET binary.

### Why this belongs in the TS wrapper (and how it relates to #65 / #46 / #42)

- #46 (closing #42) routed commands through `sh -c` when an `Arg`/`QuotedArg`
  contains `$` or a backtick. Tilde was left uncovered.
- #65 adds `ContainsTildeExpansion` for an **unquoted** leading `~` in `hypa -c`.
  That correctly fixes the `bash`-rewriter / unquoted `hypa_shell` path — but it
  cannot help the four structured tools here, because this wrapper emits the
  path **single-quoted** (`'~/…'`), which no shell expands.

So the structured-tool fix has to happen before `shellQuote`, i.e. in
`normalizePathArg`. This PR and #65 are complementary: #65 covers the shell
path, this covers the structured `path` arguments.

## The fix

```ts
function normalizePathArg(path: string): string {
  const unprefixed = path.startsWith("@") ? path.slice(1) : path;
  if (unprefixed === "~") return homedir();
  if (unprefixed.startsWith("~/")) return homedir() + unprefixed.slice(1);
  return unprefixed;
}
```

Result:

```
# hypa_read  path = "~/.bashrc"   →   now emits:
cat -- /home/you/.bashrc          # ✅ absolute, works
```

`homedir()` is cross-platform, so this also works on Windows (`C:\Users\you`);
`shellQuote` already quotes such paths correctly for cmd.exe.

## Scope / non-goals

- **`~user/…`** is intentionally left untouched — resolving another user's home
  needs the OS user database and is out of scope. It passes through unchanged
  (still single-quoted literally), exactly as today.
- The existing `@`-stripping behaviour is unchanged; `@/abs/path` still yields
  `/abs/path`.
- No change to the `bash` rewriter or `hypa_shell` shell path (that's #65).

## Testing

Added three focused tests to `test/tools.test.ts`, exercising `normalizePathArg`
through the public `build*Command` helpers (matching the existing test style):

- `~`, `~/…` expand across read/grep/find/ls.
- `@~/…` strips `@` then expands; `@/abs` still normalizes to `/abs`.
- `~user/…`, absolute, and relative paths are left untouched.

`npm run build` (tsc --noEmit) and `npm test` both pass (70/70).

---

_Suggested label: `bug`._
