### PR TITLE
Fix filters for package manager scripts

### DIFF
--- a/src/Hypa.Infrastructure/DI/InfrastructureServiceExtensions.cs
+++ b/src/Hypa.Infrastructure/DI/InfrastructureServiceExtensions.cs
@@ -126,6 +126,7 @@ public static class InfrastructureServiceExtensions
         // Filters
         services.AddSingleton<IFilterEngine, FilterEngine>();
         services.AddSingleton<FilterService>();
+        services.AddSingleton<IPackageManagerScriptResolver, PackageManagerScriptResolver>();
         services.AddSingleton<CommandRunnerService>();
         services.AddSingleton<ICommandRunnerService>(sp => sp.GetRequiredService<CommandRunnerService>());
         services.AddSingleton<IFilterRepository, FileSystemFilterRepository>();

--- a/src/Hypa.Infrastructure/Reducers/PackageManagerOutputCompressor.cs
+++ b/src/Hypa.Infrastructure/Reducers/PackageManagerOutputCompressor.cs
@@ -6,16 +6,38 @@ namespace Hypa.Infrastructure.Reducers;
 
 public sealed partial class PackageManagerOutputCompressor(ITokenCounter tokenCounter) : IOutputCompressor
 {
-    private static readonly HashSet<string> Executables = ["npm", "pnpm", "yarn"];
 
     public string Id => "pkg-manager";
 
-    public bool CanHandle(CommandInvocation invocation) =>
-        Executables.Contains(invocation.Executable);
+    public bool CanHandle(CommandInvocation invocation)
+    {
+        var executable = invocation.Executable.AsSpan();
+        var separatorIndex = Math.Max(executable.LastIndexOf('/'), executable.LastIndexOf('\\'));
+        executable = executable[(separatorIndex + 1)..];
+
+        var suffixIndex = executable.LastIndexOf('.');
+        if (suffixIndex > 0 && IsWindowsShimSuffix(executable[suffixIndex..]))
+            executable = executable[..suffixIndex];
+
+        return executable.Equals("npm", StringComparison.OrdinalIgnoreCase) ||
+               executable.Equals("pnpm", StringComparison.OrdinalIgnoreCase) ||
+               executable.Equals("yarn", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsWindowsShimSuffix(ReadOnlySpan<char> suffix) =>
+        suffix.Equals(".cmd", StringComparison.OrdinalIgnoreCase) ||
+        suffix.Equals(".exe", StringComparison.OrdinalIgnoreCase) ||
+        suffix.Equals(".bat", StringComparison.OrdinalIgnoreCase);
 
     public CompressionResult Compress(CommandInvocation invocation, CommandOutput output, CompressionOptions options)
     {
-        var combined = output.Stdout + (output.Stderr.Length > 0 ? "\n" + output.Stderr : "");
+        var combined = (output.Stdout.Length, output.Stderr.Length) switch
+        {
+            (0, 0) => string.Empty,
+            (0, _) => output.Stderr,
+            (_, 0) => output.Stdout,
+            _ => output.Stdout + "\n" + output.Stderr,
+        };
         var originalTokens = tokenCounter.EstimateTokens(combined);
 
         // successful small outputs need no reduction

--- a/src/Hypa.Runtime/Application/Ports/IPackageManagerScriptResolver.cs
+++ b/src/Hypa.Runtime/Application/Ports/IPackageManagerScriptResolver.cs
@@ -1,0 +1,8 @@
+using Hypa.Runtime.Domain.Runner;
+
+namespace Hypa.Runtime.Application.Ports;
+
+public interface IPackageManagerScriptResolver
+{
+    ResolvedPackageScript? TryResolve(CommandInvocation invocation);
+}

--- a/src/Hypa.Runtime/Application/Services/CommandRunnerService.cs
+++ b/src/Hypa.Runtime/Application/Services/CommandRunnerService.cs
@@ -1,7 +1,9 @@
+using System.Text;
 using Hypa.Runtime.Application.Ports;
 using Hypa.Runtime.Domain.Common;
 using Hypa.Runtime.Domain.Config;
 using Hypa.Runtime.Domain.Metrics;
+using Hypa.Runtime.Domain.Filters;
 using Hypa.Runtime.Domain.Parsers;
 using Hypa.Runtime.Domain.Runner;
 using Hypa.Runtime.Domain.Sessions;
@@ -17,6 +19,7 @@ public sealed class CommandRunnerService(
     IEvidenceLedger evidence,
     ISessionResolver sessionResolver,
     IConfigLoader configLoader,
+    IPackageManagerScriptResolver packageManagerScriptResolver,
     FilterService filterService,
     IFilterEngine filterEngine,
     IParseMetricsRepository parseMetrics,
@@ -30,20 +33,27 @@ public sealed class CommandRunnerService(
         CancellationToken ct)
     {
         var effectiveOptions = await ResolveCompressionOptionsAsync(options, ct);
+        var resolvedPackageScript = packageManagerScriptResolver.TryResolve(invocation);
         var runResult = await runner.RunAsync(invocation, ct);
         if (!runResult.IsOk)
             return Result<BufferedRunOutput, Error>.Fail(runResult.Error);
 
         var output = runResult.Value;
-        var combined = output.Stdout + (output.Stderr.Length > 0 ? "\n" + output.Stderr : "");
-        if (output.WasTimedOut)
-            combined = AppendTimeoutDiagnostic(combined, invocation, output);
+        var rawCombined = output.Stdout.Length == 0
+            ? output.Stderr
+            : output.Stderr.Length == 0
+                ? output.Stdout
+                : output.Stdout + "\n" + output.Stderr;
+        var combined = output.WasTimedOut
+            ? AppendTimeoutDiagnostic(rawCombined, invocation, output)
+            : rawCombined;
         var originalTokens = tokenCounter.EstimateTokens(combined);
 
         string finalText;
         string reducerId = "passthrough";
         int compressedTokens = originalTokens;
         bool wasTruncated = false;
+        bool selectedCompressedOutput = false;
 
         if (originalTokens <= effectiveOptions.SmallOutputThreshold)
         {
@@ -69,6 +79,7 @@ public sealed class CommandRunnerService(
             {
                 finalText = result.Text;
                 compressedTokens = result.CompressedTokens;
+                selectedCompressedOutput = true;
             }
         }
 
@@ -84,21 +95,60 @@ public sealed class CommandRunnerService(
             teeArtifactId = await TeeAsync(combined, sessionId, ct);
         }
 
+
         // Apply DSL filters (built-in → user-global → trusted project-local)
         string? appliedFilterId = null;
-        foreach (var filter in filterService.GetApplicableFilters(invocation.Executable, invocation.OriginalCommand))
+        bool fallbackDiagnosticsComposed = false;
+        var filterExecutable = resolvedPackageScript?.Executable ?? invocation.Executable;
+        var filterCommand = resolvedPackageScript?.Command ?? invocation.OriginalCommand;
+        foreach (var filter in filterService.GetApplicableFilters(filterExecutable, filterCommand))
         {
-            var textForFilter = filter.MergeStderr && output.Stderr.Length > 0
-                ? finalText.TrimEnd() + "\n" + output.Stderr
-                : finalText;
-            var fr = filterEngine.Apply(filter, textForFilter);
-            var voided = string.IsNullOrWhiteSpace(fr.Text) && !string.IsNullOrWhiteSpace(finalText);
-            if (fr.StagesApplied > 0 && !voided)
+            var isSpecificResolvedFilter = resolvedPackageScript is not null
+                && (filter.AppliesTo.Count > 0 || filter.CompiledMatchCommand is not null);
+            if (!isSpecificResolvedFilter &&
+                resolvedPackageScript is not null &&
+                selectedCompressedOutput &&
+                !fallbackDiagnosticsComposed)
             {
-                finalText = fr.Text;
+                finalText = AppendResolvedDiagnostics(finalText, invocation, output);
+                fallbackDiagnosticsComposed = true;
+            }
+            var textForFilter = isSpecificResolvedFilter
+                ? rawCombined
+                : resolvedPackageScript is not null
+                    ? finalText
+                    : filter.MergeStderr && output.Stderr.Length > 0
+                        ? finalText.TrimEnd() + "\n" + output.Stderr
+                        : finalText;
+            var fr = filterEngine.Apply(filter, textForFilter);
+            var voided = string.IsNullOrWhiteSpace(fr.Text) &&
+                !string.IsNullOrWhiteSpace(
+                    isSpecificResolvedFilter ? textForFilter : finalText);
+            var rejectedFailureOnEmptyOrMatchOutputReplacement =
+                isSpecificResolvedFilter &&
+                (output.ExitCode != 0 || output.WasTimedOut) &&
+                filter.Stages.Any(stage =>
+                    stage.Stage.Replacement is not null &&
+                    stage.Stage.Kind is FilterStageKind.OnEmpty or FilterStageKind.MatchOutput &&
+                    string.Equals(fr.Text, stage.Stage.Replacement, StringComparison.Ordinal));
+            if (fr.StagesApplied > 0 && !voided && !rejectedFailureOnEmptyOrMatchOutputReplacement)
+            {
+                finalText = isSpecificResolvedFilter
+                    ? output.WasTimedOut
+                        ? AppendContentLinesIfMissing(fr.Text, CreateTimeoutDiagnostic(invocation, output))
+                        : fr.Text
+                    : fr.Text;
                 appliedFilterId = filter.Id;
                 break;
             }
+        }
+
+        if (appliedFilterId is null &&
+            resolvedPackageScript is not null &&
+            selectedCompressedOutput &&
+            !fallbackDiagnosticsComposed)
+        {
+            finalText = AppendResolvedDiagnostics(finalText, invocation, output);
         }
 
         compressedTokens = tokenCounter.EstimateTokens(finalText);
@@ -254,15 +304,84 @@ public sealed class CommandRunnerService(
         }
     }
 
+    private static string AppendResolvedDiagnostics(
+        string filteredStdout,
+        CommandInvocation invocation,
+        CommandOutput output) =>
+        AppendContentLinesIfMissing(
+            filteredStdout,
+            output.Stderr,
+            output.WasTimedOut ? CreateTimeoutDiagnostic(invocation, output) : null);
+
+    private static string AppendContentLinesIfMissing(
+        string text,
+        string content,
+        string? additionalContent = null)
+    {
+        if (content.Length == 0 && string.IsNullOrEmpty(additionalContent))
+            return text;
+
+        var remainingExistingCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var rawLine in text.Split('\n'))
+        {
+            var line = NormalizeLine(rawLine);
+            if (line.Length == 0)
+                continue;
+
+            remainingExistingCounts.TryGetValue(line, out var count);
+            remainingExistingCounts[line] = count + 1;
+        }
+
+        StringBuilder? result = null;
+        AppendMissingLines(content, text, remainingExistingCounts, ref result);
+        if (!string.IsNullOrEmpty(additionalContent))
+            AppendMissingLines(additionalContent, text, remainingExistingCounts, ref result);
+
+        return result?.ToString() ?? text;
+    }
+
+    private static void AppendMissingLines(
+        string content,
+        string originalText,
+        Dictionary<string, int> remainingExistingCounts,
+        ref StringBuilder? result)
+    {
+        foreach (var rawLine in content.Split('\n'))
+        {
+            var line = NormalizeLine(rawLine);
+            if (line.Length == 0)
+                continue;
+
+            if (remainingExistingCounts.TryGetValue(line, out var remainingCount) &&
+                remainingCount > 0)
+            {
+                remainingExistingCounts[line] = remainingCount - 1;
+                continue;
+            }
+
+            result ??= new StringBuilder(originalText);
+            if (result.Length > 0 && result[^1] != '\n')
+                result.Append('\n');
+            result.Append(line);
+        }
+    }
+
+    private static string NormalizeLine(string rawLine) =>
+        rawLine.EndsWith('\r') ? rawLine[..^1] : rawLine;
+
+    private static string CreateTimeoutDiagnostic(
+        CommandInvocation invocation,
+        CommandOutput output) =>
+        $"[hypa: command timed out after {invocation.Timeout.TotalSeconds:0.###}s; " +
+        $"killed process; exit={CommandOutput.TimeoutExitCode}; " +
+        $"elapsed={output.Duration.TotalSeconds:0.###}s]";
+
     private static string AppendTimeoutDiagnostic(
         string text,
         CommandInvocation invocation,
         CommandOutput output)
     {
-        var line =
-            $"[hypa: command timed out after {invocation.Timeout.TotalSeconds:0.###}s; " +
-            $"killed process; exit={CommandOutput.TimeoutExitCode}; " +
-            $"elapsed={output.Duration.TotalSeconds:0.###}s]";
+        var line = CreateTimeoutDiagnostic(invocation, output);
 
         return string.IsNullOrWhiteSpace(text)
             ? line

--- a/src/Hypa.Runtime/Application/Services/PackageManagerScriptResolver.cs
+++ b/src/Hypa.Runtime/Application/Services/PackageManagerScriptResolver.cs
@@ -1,0 +1,352 @@
+using System.Text.Json;
+using Hypa.Runtime.Application.Ports;
+using Hypa.Runtime.Domain.Rewrite;
+using Hypa.Runtime.Domain.Runner;
+
+namespace Hypa.Runtime.Application.Services;
+
+public sealed class PackageManagerScriptResolver(
+    IFileSystem fileSystem,
+    IShellLexer shellLexer) : IPackageManagerScriptResolver
+{
+    private static readonly HashSet<string> PackageManagers =
+        new(StringComparer.OrdinalIgnoreCase) { "npm", "pnpm", "yarn" };
+
+    private static readonly HashSet<string> SafeLeadingOptions =
+        new(StringComparer.OrdinalIgnoreCase) { "--silent", "-s" };
+
+    private static readonly Dictionary<string, string> NpmLifecycleScripts =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["test"] = "test",
+            ["t"] = "test",
+            ["tst"] = "test",
+            ["start"] = "start",
+            ["stop"] = "stop",
+            ["restart"] = "restart",
+        };
+
+    private static readonly HashSet<string> PnpmBuiltInCommands =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "add", "approve-builds", "audit", "bin", "bugs", "c", "cache", "catalog", "cat-file",
+            "cat-index", "ci", "clean", "completion", "config", "create", "dedupe", "deploy",
+            "deprecate", "dist-tag", "dlx", "docs", "doctor", "env", "exec", "x", "fetch",
+            "find-hash", "help", "ignored-builds", "import", "init", "install", "i",
+            "install-test", "it", "licenses", "link", "list", "ls", "login", "logout", "outdated",
+            "owner", "pack", "pack-app", "patch", "patch-commit", "patch-remove", "peers", "ping",
+            "pkg", "pm", "pnx", "prefix", "prune", "publish", "rebuild", "recursive", "remove",
+            "rm", "repo", "root", "run", "run-script", "runtime", "sbom", "search", "self-update",
+            "server", "set-script", "setup", "stage", "star", "store", "unlink", "uninstall",
+            "un", "unpublish", "update", "up", "upgrade", "version", "view", "whoami", "why",
+            "with", "workspace", "workspaces",
+        };
+
+    private static readonly HashSet<string> YarnBuiltInCommands =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "add", "audit", "autoclean", "bin", "cache", "check", "config", "constraints", "create",
+            "dedupe", "dlx", "exec", "x", "explain", "generate-lock-entry", "global", "help", "import",
+            "info", "init", "install", "i", "licenses", "link", "list", "lockfile", "ls", "login",
+            "logout", "node", "npm", "outdated", "owner", "pack", "patch", "patch-commit", "plugin", "policies",
+            "prune", "publish", "rebuild", "remove", "rm", "run-script", "search", "self-update",
+            "set", "stage", "tag", "team", "unlink", "uninstall", "un", "unplug", "up", "update",
+            "upgrade", "upgrade-interactive", "version", "versions", "why", "workspace", "workspaces",
+        };
+
+    public ResolvedPackageScript? TryResolve(CommandInvocation invocation)
+    {
+        try
+        {
+            var packageManager = NormalizeExecutable(invocation.Executable);
+            if (!PackageManagers.Contains(packageManager))
+                return null;
+
+            if (string.Equals(packageManager, "npm", StringComparison.OrdinalIgnoreCase) &&
+                HasNpmTargetChangingOption(invocation.Arguments))
+            {
+                return null;
+            }
+
+            var scriptName = ExtractScriptName(packageManager, invocation.Arguments);
+            if (scriptName is null)
+                return null;
+
+            var workingDirectory = invocation.WorkingDirectory ?? fileSystem.GetCurrentDirectory();
+            var packageJsonPath = Path.Combine(workingDirectory, "package.json");
+            if (!fileSystem.FileExists(packageJsonPath))
+                return null;
+
+            using var document = JsonDocument.Parse(fileSystem.ReadAllText(packageJsonPath));
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object ||
+                !root.TryGetProperty("scripts", out var scripts) ||
+                scripts.ValueKind != JsonValueKind.Object ||
+                !scripts.TryGetProperty(scriptName, out var script) ||
+                script.ValueKind != JsonValueKind.String)
+            {
+                return null;
+            }
+
+            if (scripts.TryGetProperty($"pre{scriptName}", out _) ||
+                scripts.TryGetProperty($"post{scriptName}", out _))
+            {
+                return null;
+            }
+
+            var command = script.GetString();
+            if (string.IsNullOrWhiteSpace(command))
+                return null;
+
+            var resolvedCommand = ExtractCanonicalCommand(command);
+            return resolvedCommand is null
+                ? null
+                : new ResolvedPackageScript(
+                    resolvedCommand.Value.Executable,
+                    resolvedCommand.Value.Command);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    private static string? ExtractScriptName(
+        string packageManager,
+        IReadOnlyList<string> arguments)
+    {
+        var commandIndex = 0;
+        while (commandIndex < arguments.Count &&
+               SafeLeadingOptions.Contains(arguments[commandIndex]))
+        {
+            commandIndex++;
+        }
+
+        if (commandIndex >= arguments.Count)
+            return null;
+
+        var command = arguments[commandIndex];
+        if (!IsValidScriptName(command))
+            return null;
+
+        if (IsExplicitRunCommand(packageManager, command))
+        {
+            var scriptIndex = commandIndex + 1;
+            while (scriptIndex < arguments.Count &&
+                   SafeLeadingOptions.Contains(arguments[scriptIndex]))
+            {
+                scriptIndex++;
+            }
+
+            return scriptIndex < arguments.Count && IsValidScriptName(arguments[scriptIndex])
+                ? arguments[scriptIndex]
+                : null;
+        }
+
+        if (string.Equals(packageManager, "npm", StringComparison.OrdinalIgnoreCase))
+        {
+            return NpmLifecycleScripts.TryGetValue(command, out var lifecycleScript)
+                ? lifecycleScript
+                : null;
+        }
+
+        if (string.Equals(packageManager, "pnpm", StringComparison.OrdinalIgnoreCase) &&
+            (string.Equals(command, "t", StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(command, "tst", StringComparison.OrdinalIgnoreCase)))
+        {
+            return "test";
+        }
+
+        return !IsBuiltInCommand(packageManager, command)
+            ? command
+            : null;
+    }
+
+    private static bool HasNpmTargetChangingOption(IReadOnlyList<string> arguments)
+    {
+        foreach (var argument in arguments)
+        {
+            if (string.Equals(argument, "--", StringComparison.Ordinal))
+                return false;
+
+            if (IsNpmTargetChangingOption(argument))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsNpmTargetChangingOption(string argument) =>
+        string.Equals(argument, "--workspace", StringComparison.Ordinal) ||
+        argument.StartsWith("--workspace=", StringComparison.Ordinal) ||
+        string.Equals(argument, "--workspaces", StringComparison.Ordinal) ||
+        argument.StartsWith("--workspaces=", StringComparison.Ordinal) ||
+        string.Equals(argument, "--ws", StringComparison.Ordinal) ||
+        argument.StartsWith("--ws=", StringComparison.Ordinal) ||
+        string.Equals(argument, "-ws", StringComparison.Ordinal) ||
+        argument.StartsWith("-ws=", StringComparison.Ordinal) ||
+        string.Equals(argument, "-w", StringComparison.Ordinal) ||
+        argument.StartsWith("-w=", StringComparison.Ordinal) ||
+        string.Equals(argument, "--prefix", StringComparison.Ordinal) ||
+        argument.StartsWith("--prefix=", StringComparison.Ordinal) ||
+        string.Equals(argument, "-C", StringComparison.Ordinal) ||
+        argument.StartsWith("-C=", StringComparison.Ordinal);
+
+    private static bool IsExplicitRunCommand(string packageManager, string command) =>
+        string.Equals(command, "run", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(command, "run-script", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(packageManager, "npm", StringComparison.OrdinalIgnoreCase) &&
+        (string.Equals(command, "rum", StringComparison.OrdinalIgnoreCase) ||
+         string.Equals(command, "urn", StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsValidScriptName(string value) =>
+        !string.IsNullOrWhiteSpace(value) && value[0] != '-';
+
+    private static bool IsBuiltInCommand(string packageManager, string command) =>
+        packageManager switch
+        {
+            "pnpm" => PnpmBuiltInCommands.Contains(command),
+            "yarn" => YarnBuiltInCommands.Contains(command),
+            _ => true,
+        };
+
+    private (string Executable, string Command)? ExtractCanonicalCommand(string command)
+    {
+        var tokens = shellLexer.Lex(command);
+        var canSkipAssignments = true;
+
+        for (var i = 0; i < tokens.Count; i++)
+        {
+            var token = tokens[i];
+            if (token.Kind == TokenKind.Whitespace)
+                continue;
+
+            if (token.Kind is TokenKind.Operator or
+                TokenKind.Pipe or
+                TokenKind.Redirect or
+                TokenKind.Shellism)
+            {
+                return null;
+            }
+
+            if (token.Kind == TokenKind.Arg)
+            {
+                if (canSkipAssignments && IsAssignment(token.Value))
+                {
+                    if (OperatingSystem.IsWindows())
+                        return null;
+
+                    while (i + 1 < tokens.Count &&
+                           tokens[i + 1].Kind is TokenKind.Arg or TokenKind.QuotedArg)
+                    {
+                        i++;
+                    }
+
+                    continue;
+                }
+
+                if (HasAdjacentArgumentSegment(tokens, i))
+                    return null;
+
+                return CreateCanonicalCommand(command, token, token.Value);
+            }
+
+            if (token.Kind == TokenKind.QuotedArg &&
+                HasAdjacentArgumentSegment(tokens, i))
+            {
+                return null;
+            }
+
+            if (token.Kind == TokenKind.QuotedArg)
+                return CreateCanonicalCommand(command, token, StripQuotes(token.Value));
+
+            canSkipAssignments = false;
+        }
+
+        return null;
+    }
+
+    private static bool HasAdjacentArgumentSegment(
+        IReadOnlyList<ShellToken> tokens,
+        int candidateIndex)
+    {
+        var candidate = tokens[candidateIndex];
+        return candidateIndex > 0 &&
+               IsArgumentSegment(tokens[candidateIndex - 1]) &&
+               tokens[candidateIndex - 1].Offset +
+               tokens[candidateIndex - 1].Value.Length == candidate.Offset ||
+               candidateIndex + 1 < tokens.Count &&
+               IsArgumentSegment(tokens[candidateIndex + 1]) &&
+               candidate.Offset + candidate.Value.Length ==
+               tokens[candidateIndex + 1].Offset;
+    }
+
+    private static bool IsArgumentSegment(ShellToken token) =>
+        token.Kind is TokenKind.Arg or TokenKind.QuotedArg;
+
+    private static (string Executable, string Command)? CreateCanonicalCommand(
+        string command,
+        ShellToken leadToken,
+        string leadExecutable)
+    {
+        var executable = NormalizeLeadExecutable(leadExecutable);
+        if (executable is null)
+            return null;
+
+        var suffixOffset = leadToken.Offset + leadToken.Value.Length;
+        return (executable, executable + command[suffixOffset..]);
+    }
+
+    private static bool IsAssignment(string value)
+    {
+        if (value.Length < 2 || (value[0] != '_' && !IsAsciiLetter(value[0])))
+            return false;
+
+        for (var i = 1; i < value.Length; i++)
+        {
+            var ch = value[i];
+            if (ch == '=')
+                return true;
+
+            if (ch != '_' && !IsAsciiLetter(ch) && !char.IsAsciiDigit(ch))
+                return false;
+        }
+
+        return false;
+    }
+
+    private static bool IsAsciiLetter(char ch) =>
+        ch is >= 'A' and <= 'Z' or >= 'a' and <= 'z';
+
+    private static string StripQuotes(string value)
+    {
+        if (value.Length >= 2 && ((value[0] == '\'' && value[^1] == '\'') ||
+                                  (value[0] == '"' && value[^1] == '"')))
+        {
+            return value[1..^1];
+        }
+
+        return value;
+    }
+
+    private static string? NormalizeLeadExecutable(string value)
+    {
+        var executable = NormalizeExecutable(value);
+        return executable.Length == 0 ? null : executable;
+    }
+
+    private static string NormalizeExecutable(string executable)
+    {
+        var slashIndex = executable.LastIndexOf('/');
+        var backslashIndex = executable.LastIndexOf('\\');
+        var fileName = executable[(Math.Max(slashIndex, backslashIndex) + 1)..];
+        var normalizedFileName =
+            fileName.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase) ||
+            fileName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ||
+            fileName.EndsWith(".bat", StringComparison.OrdinalIgnoreCase)
+                ? fileName[..^4]
+                : fileName;
+        return normalizedFileName.ToLowerInvariant();
+    }
+
+}

--- a/src/Hypa.Runtime/Domain/Runner/ResolvedPackageScript.cs
+++ b/src/Hypa.Runtime/Domain/Runner/ResolvedPackageScript.cs
@@ -1,0 +1,3 @@
+namespace Hypa.Runtime.Domain.Runner;
+
+public sealed record ResolvedPackageScript(string Executable, string Command);

--- a/tests/Hypa.UnitTests/Application/CommandRunnerServiceTests.cs
+++ b/tests/Hypa.UnitTests/Application/CommandRunnerServiceTests.cs
@@ -1,3 +1,6 @@
+using System.Text.RegularExpressions;
+using Hypa.Infrastructure.Filters;
+using Hypa.Infrastructure.Reducers;
 using Hypa.Runtime.Application.Ports;
 using Hypa.Runtime.Application.Services;
 using Hypa.Runtime.Domain.Common;
@@ -27,7 +30,8 @@ public sealed class CommandRunnerServiceTests
         IConfigLoader? configLoader = null,
         IFilterRepository? filterRepo = null,
         IFilterEngine? filterEngine = null,
-        IParseMetricsRepository? parseMetrics = null)
+        IParseMetricsRepository? parseMetrics = null,
+        IPackageManagerScriptResolver? packageScriptResolver = null)
     {
         runner ??= Substitute.For<ICommandRunner>();
         compressor ??= MakePassthroughCompressor();
@@ -36,6 +40,7 @@ public sealed class CommandRunnerServiceTests
         evidence ??= Substitute.For<IEvidenceLedger>();
         resolver ??= MakeResolver();
         configLoader ??= MakeConfigLoader(HypaConfig.Default);
+        packageScriptResolver ??= Substitute.For<IPackageManagerScriptResolver>();
 
         if (filterRepo is null)
         {
@@ -62,6 +67,7 @@ public sealed class CommandRunnerServiceTests
             evidence,
             resolver,
             configLoader,
+            packageScriptResolver,
             filterService,
             filterEngine,
             parseMetrics,
@@ -394,6 +400,1155 @@ public sealed class CommandRunnerServiceTests
         Assert.Equal("dotnet-msbuild-noise", recorded.FilterId);
         filterEngine.Received(1).Apply(dotnet, Arg.Any<string>());
         filterEngine.DidNotReceive().Apply(universal, Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task RunBufferedAsync_ResolvedPackageScript_UsesFullResolvedCommandForFilterAndRawInvocationEverywhereElse()
+    {
+        var invocation = CommandInvocation.Buffered(
+            "pnpm",
+            ["test", "--", "--reporter=dot"],
+            "pnpm test -- --reporter=dot");
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured(new string('x', 400), "", 0, TimeSpan.Zero)));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript("jest", "jest --runInBand"));
+
+        var jestFilter = new CompiledFilterDefinition
+        {
+            Id = "jest",
+            AppliesTo = ["jest"],
+            MatchCommand = @"^jest\s+--runInBand$",
+            CompiledMatchCommand = new Regex(@"^jest\s+--runInBand$", RegexOptions.CultureInvariant),
+            Stages = [],
+        };
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([jestFilter]);
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(jestFilter, Arg.Any<string>())
+            .Returns(new FilterResult("jest-filtered", jestFilter.Id, 1));
+
+        CommandMetricsRecord? commandMetrics = null;
+        var evidence = Substitute.For<IEvidenceLedger>();
+        evidence.RecordCommandMetricsAsync(
+                Arg.Do<CommandMetricsRecord>(record => commandMetrics = record),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        ParseMetricsRecord? parseMetrics = null;
+        var parseMetricsRepository = Substitute.For<IParseMetricsRepository>();
+        parseMetricsRepository.RecordAsync(
+                Arg.Do<ParseMetricsRecord>(record => parseMetrics = record),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var compressor = MakePassthroughCompressor();
+        var service = MakeService(
+            runner: runner,
+            compressor: compressor,
+            evidence: evidence,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            parseMetrics: parseMetricsRepository,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default,
+            CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Contains("jest-filtered", result.Value.Text);
+        await runner.Received(1).RunAsync(
+            Arg.Is<CommandInvocation>(candidate => ReferenceEquals(candidate, invocation)),
+            Arg.Any<CancellationToken>());
+        packageScriptResolver.Received(1).TryResolve(invocation);
+        compressor.Received(1).CanHandle(
+            Arg.Is<CommandInvocation>(candidate => ReferenceEquals(candidate, invocation)));
+        compressor.Received(1).Compress(
+            Arg.Is<CommandInvocation>(candidate => ReferenceEquals(candidate, invocation)),
+            Arg.Any<CommandOutput>(),
+            Arg.Any<CompressionOptions>());
+        filterEngine.Received(1).Apply(jestFilter, Arg.Any<string>());
+
+        Assert.NotNull(commandMetrics);
+        Assert.Equal("pnpm test -- --reporter=dot", commandMetrics.Command);
+        Assert.NotNull(parseMetrics);
+        Assert.Equal("pnpm", parseMetrics.Executable);
+        Assert.Equal("test -- --reporter=dot", parseMetrics.Arguments);
+        Assert.Equal(jestFilter.Id, parseMetrics.FilterId);
+    }
+
+    [Fact]
+    public async Task RunBufferedAsync_ResolvedEslintFilter_ReceivesRawPackageScriptOutput()
+    {
+        const string fileName = "/workspace/src/dashboard.ts";
+        const string summary = "✖ 80 problems (80 errors, 0 warnings)";
+        var violations = Enumerable.Range(1, 80)
+            .Select(line => $"  {line}:5  error  Unexpected console statement  no-console");
+        var rawOutput = fileName + "\n" +
+            string.Join('\n', violations) +
+            "\n\n" + summary;
+        var invocation = CommandInvocation.Buffered("pnpm", ["lint"], "pnpm lint");
+        var captured = CommandOutput.Captured(rawOutput, "", 1, TimeSpan.Zero);
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(captured));
+
+        var tokenCounter = MakeBigTokenCounter();
+        var compressor = new PackageManagerOutputCompressor(tokenCounter);
+        var options = CompressionOptions.Default with { ShowCompressionMetadata = false };
+        var packageManagerResult = compressor.Compress(invocation, captured, options);
+        Assert.DoesNotContain(fileName, packageManagerResult.Text);
+        Assert.DoesNotContain(summary, packageManagerResult.Text);
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript("eslint", "eslint --max-warnings 0 ."));
+        var eslintFilter = BuiltInFilters.All.Single(filter => filter.Id == "eslint");
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([eslintFilter]);
+        var service = MakeService(
+            runner: runner,
+            compressor: compressor,
+            tokenCounter: tokenCounter,
+            filterRepo: filterRepo,
+            filterEngine: new FilterEngine(),
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(invocation, options, CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Contains(fileName, result.Value.Text);
+        Assert.Contains(summary, result.Value.Text);
+    }
+
+    [Fact]
+    public async Task RunBufferedAsync_TimedOutResolvedFilterWithoutMerge_ReceivesCombinedStreamAndAppendsTimeoutAfterFilteredResult()
+    {
+        const string stderr = "fatal: test worker exited before producing stdout" +
+            "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" +
+            "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!";
+        const string filtered = "test worker: failed";
+        const string timeoutDiagnostic =
+            "[hypa: command timed out after 30s; killed process; exit=124; elapsed=31s]";
+        var invocation = CommandInvocation.Buffered("pnpm", ["test"], "pnpm test");
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.CreateTimedOut(TimeSpan.FromSeconds(31), stderr: stderr)));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript("jest", "jest --runInBand"));
+        var filter = new CompiledFilterDefinition
+        {
+            Id = "jest",
+            AppliesTo = ["jest"],
+            MergeStderr = false,
+            Stages = [],
+        };
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([filter]);
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(filter, Arg.Any<string>())
+            .Returns(new FilterResult(filtered, filter.Id, 1));
+        var service = MakeService(
+            runner: runner,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default with { ShowCompressionMetadata = false },
+            CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Equal(CommandOutput.TimeoutExitCode, result.Value.ExitCode);
+        Assert.Equal(filtered + "\n" + timeoutDiagnostic, result.Value.Text);
+        Assert.DoesNotContain(stderr, result.Value.Text);
+        Assert.Single(Regex.Matches(result.Value.Text, Regex.Escape(timeoutDiagnostic)));
+        filterEngine.Received(1).Apply(filter, stderr);
+    }
+
+    [Theory]
+    [InlineData("jest", "jest --runInBand")]
+    [InlineData("vitest", "vitest run")]
+    public async Task RunBufferedAsync_ResolvedJestOrVitest_ProcessesStderrOnlyFailureReport(
+        string executable,
+        string resolvedCommand)
+    {
+        const string stderr = "\x1B[31mFAIL src/checkout.test.ts\x1B[0m\n" +
+            "Tests: 1 failed, 2 passed, 3 total\n" +
+            "Expected true\n" +
+            "Received false";
+        const string expected = "FAIL src/checkout.test.ts\n" +
+            "Tests: 1 failed, 2 passed, 3 total\n" +
+            "Expected true\n" +
+            "Received false";
+        var invocation = CommandInvocation.Buffered("pnpm", ["test"], "pnpm test");
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("", stderr, 1, TimeSpan.Zero)));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript(executable, resolvedCommand));
+        var filter = BuiltInFilters.All.Single(candidate => candidate.Id == "jest");
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([filter]);
+        var realFilterEngine = new FilterEngine();
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(filter, Arg.Any<string>())
+            .Returns(ci => realFilterEngine.Apply(filter, ci.ArgAt<string>(1)));
+        var service = MakeService(
+            runner: runner,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default with { ShowCompressionMetadata = false },
+            CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Equal(1, result.Value.ExitCode);
+        Assert.Equal(expected, result.Value.Text);
+        Assert.DoesNotContain("jest: ok", result.Value.Text);
+        filterEngine.Received(1).Apply(filter, stderr);
+    }
+
+    [Fact]
+    public async Task RunBufferedAsync_ResolvedJest_NonzeroCoverageThresholdFailureRejectsMatchOutputSuccess()
+    {
+        const string coverageFailure =
+            "Jest: \"global\" coverage threshold for statements (90%) not met: 80%";
+        const string rawOutput = "Tests: 4 passed, 4 total\n" + coverageFailure;
+        const string compressedFallback = "\x1B[31m" + coverageFailure + "\x1B[0m";
+        var invocation = CommandInvocation.Buffered("pnpm", ["test"], "pnpm test");
+        var captured = CommandOutput.Captured(rawOutput, "", 1, TimeSpan.Zero);
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(captured));
+
+        var compressor = Substitute.For<IOutputCompressor>();
+        compressor.Id.Returns("package-manager");
+        compressor.CanHandle(Arg.Any<CommandInvocation>()).Returns(true);
+        compressor.Compress(
+                Arg.Any<CommandInvocation>(),
+                Arg.Any<CommandOutput>(),
+                Arg.Any<CompressionOptions>())
+            .Returns(CompressionResult.From(
+                compressedFallback,
+                100,
+                1,
+                "package-manager",
+                [],
+                false));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript("jest", "jest --runInBand"));
+        var jestFilter = BuiltInFilters.All.Single(candidate => candidate.Id == "jest");
+        var universal = BuiltInFilters.All.Single(candidate => candidate.Id == "ansi-strip");
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([jestFilter, universal]);
+        var realFilterEngine = new FilterEngine();
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(jestFilter, Arg.Any<string>())
+            .Returns(ci => realFilterEngine.Apply(jestFilter, ci.ArgAt<string>(1)));
+        filterEngine.Apply(universal, Arg.Any<string>())
+            .Returns(ci => realFilterEngine.Apply(universal, ci.ArgAt<string>(1)));
+        var service = MakeService(
+            runner: runner,
+            compressor: compressor,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default with
+            {
+                SmallOutputThreshold = 0,
+                ShowCompressionMetadata = false,
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Equal(1, result.Value.ExitCode);
+        Assert.Equal(coverageFailure, result.Value.Text);
+        Assert.DoesNotContain("jest: ok (all passed)", result.Value.Text);
+        compressor.Received(1).Compress(
+            invocation,
+            captured,
+            Arg.Any<CompressionOptions>());
+        filterEngine.Received(1).Apply(jestFilter, rawOutput);
+        filterEngine.Received(1).Apply(universal, compressedFallback);
+    }
+
+    [Fact]
+    public async Task RunBufferedAsync_ResolvedJest_ZeroExitPassingSummaryRetainsMatchOutputSuccess()
+    {
+        const string rawOutput = "Tests: 4 passed, 4 total";
+        var invocation = CommandInvocation.Buffered("pnpm", ["test"], "pnpm test");
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured(rawOutput, "", 0, TimeSpan.Zero)));
+
+        var compressor = Substitute.For<IOutputCompressor>();
+        compressor.Id.Returns("package-manager");
+        compressor.CanHandle(Arg.Any<CommandInvocation>()).Returns(true);
+        compressor.Compress(
+                Arg.Any<CommandInvocation>(),
+                Arg.Any<CommandOutput>(),
+                Arg.Any<CompressionOptions>())
+            .Returns(CompressionResult.From(
+                "compressed output that should not win",
+                100,
+                1,
+                "package-manager",
+                [],
+                false));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript("jest", "jest --runInBand"));
+        var jestFilter = BuiltInFilters.All.Single(candidate => candidate.Id == "jest");
+        var universal = BuiltInFilters.All.Single(candidate => candidate.Id == "ansi-strip");
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([jestFilter, universal]);
+        var realFilterEngine = new FilterEngine();
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(jestFilter, Arg.Any<string>())
+            .Returns(ci => realFilterEngine.Apply(jestFilter, ci.ArgAt<string>(1)));
+        filterEngine.Apply(universal, Arg.Any<string>())
+            .Returns(ci => realFilterEngine.Apply(universal, ci.ArgAt<string>(1)));
+        var service = MakeService(
+            runner: runner,
+            compressor: compressor,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default with
+            {
+                SmallOutputThreshold = 0,
+                ShowCompressionMetadata = false,
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Equal(0, result.Value.ExitCode);
+        Assert.Equal("jest: ok (all passed)", result.Value.Text);
+        compressor.Received(1).Compress(
+            invocation,
+            Arg.Any<CommandOutput>(),
+            Arg.Any<CompressionOptions>());
+        filterEngine.Received(1).Apply(jestFilter, rawOutput);
+        filterEngine.DidNotReceive().Apply(universal, Arg.Any<string>());
+    }
+
+    [Theory]
+    [InlineData("jest", "jest --runInBand")]
+    [InlineData("vitest", "vitest run")]
+    public async Task RunBufferedAsync_ResolvedJestOrVitest_NonzeroEmptyOutputRejectsOnEmptySuccess(
+        string executable,
+        string resolvedCommand)
+    {
+        var invocation = CommandInvocation.Buffered("pnpm", ["test"], "pnpm test");
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("", "", 1, TimeSpan.Zero)));
+
+        var compressor = Substitute.For<IOutputCompressor>();
+        compressor.Id.Returns("package-manager");
+        compressor.CanHandle(Arg.Any<CommandInvocation>()).Returns(true);
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript(executable, resolvedCommand));
+        var jestFilter = BuiltInFilters.All.Single(candidate => candidate.Id == "jest");
+        var universal = BuiltInFilters.All.Single(candidate => candidate.Id == "ansi-strip");
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([jestFilter, universal]);
+        var realFilterEngine = new FilterEngine();
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(jestFilter, Arg.Any<string>())
+            .Returns(ci => realFilterEngine.Apply(jestFilter, ci.ArgAt<string>(1)));
+        filterEngine.Apply(universal, Arg.Any<string>())
+            .Returns(ci => realFilterEngine.Apply(universal, ci.ArgAt<string>(1)));
+        var service = MakeService(
+            runner: runner,
+            compressor: compressor,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default with { ShowCompressionMetadata = false },
+            CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Equal(1, result.Value.ExitCode);
+        Assert.Empty(result.Value.Text);
+        Assert.DoesNotContain("jest: ok", result.Value.Text);
+        filterEngine.Received(1).Apply(jestFilter, "");
+        filterEngine.Received(1).Apply(universal, "");
+        compressor.DidNotReceive().Compress(
+            Arg.Any<CommandInvocation>(), Arg.Any<CommandOutput>(), Arg.Any<CompressionOptions>());
+    }
+
+    [Fact]
+    public async Task RunBufferedAsync_TimedOutResolvedVitest_WrapperOnlyOutputRejectsOnEmptySuccess()
+    {
+        const string wrapperOnly = "> workspace@1.0.0 test\n> vitest run";
+        const string compressedFallback = "\x1B[31mcompressed package-manager wrapper\x1B[0m";
+        const string filteredFallback = "compressed package-manager wrapper";
+        const string timeoutDiagnostic =
+            "[hypa: command timed out after 30s; killed process; exit=124; elapsed=31s]";
+        var composedFallback = compressedFallback + "\n" + timeoutDiagnostic;
+        var invocation = CommandInvocation.Buffered("pnpm", ["test"], "pnpm test");
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.CreateTimedOut(TimeSpan.FromSeconds(31), wrapperOnly)));
+
+        var compressor = Substitute.For<IOutputCompressor>();
+        compressor.Id.Returns("package-manager");
+        compressor.CanHandle(Arg.Any<CommandInvocation>()).Returns(true);
+        compressor.Compress(
+                Arg.Any<CommandInvocation>(),
+                Arg.Any<CommandOutput>(),
+                Arg.Any<CompressionOptions>())
+            .Returns(CompressionResult.From(
+                compressedFallback,
+                20,
+                5,
+                "package-manager",
+                [],
+                false));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript("vitest", "vitest run"));
+        var jestFilter = BuiltInFilters.All.Single(candidate => candidate.Id == "jest");
+        var universal = BuiltInFilters.All.Single(candidate => candidate.Id == "ansi-strip");
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([jestFilter, universal]);
+        var realFilterEngine = new FilterEngine();
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(jestFilter, Arg.Any<string>())
+            .Returns(ci => realFilterEngine.Apply(jestFilter, ci.ArgAt<string>(1)));
+        filterEngine.Apply(universal, Arg.Any<string>())
+            .Returns(ci => realFilterEngine.Apply(universal, ci.ArgAt<string>(1)));
+        var service = MakeService(
+            runner: runner,
+            compressor: compressor,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default with
+            {
+                SmallOutputThreshold = 0,
+                ShowCompressionMetadata = false,
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Equal(CommandOutput.TimeoutExitCode, result.Value.ExitCode);
+        Assert.Equal(filteredFallback + "\n" + timeoutDiagnostic, result.Value.Text);
+        Assert.DoesNotContain("jest: ok", result.Value.Text);
+        Assert.Single(Regex.Matches(result.Value.Text, Regex.Escape(timeoutDiagnostic)));
+        filterEngine.Received(1).Apply(jestFilter, wrapperOnly);
+        filterEngine.Received(1).Apply(universal, composedFallback);
+    }
+
+    [Theory]
+    [InlineData("jest", "jest --runInBand")]
+    [InlineData("vitest", "vitest run")]
+    public async Task RunBufferedAsync_ResolvedJestOrVitest_ZeroExitEmptyOutputRetainsOnEmptySuccess(
+        string executable,
+        string resolvedCommand)
+    {
+        const string compressedFallback = "\x1B[31mcompressed output that should not win\x1B[0m";
+        var invocation = CommandInvocation.Buffered("pnpm", ["test"], "pnpm test");
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("", "", 0, TimeSpan.Zero)));
+
+        var compressor = Substitute.For<IOutputCompressor>();
+        compressor.Id.Returns("package-manager");
+        compressor.CanHandle(Arg.Any<CommandInvocation>()).Returns(true);
+        compressor.Compress(
+                Arg.Any<CommandInvocation>(),
+                Arg.Any<CommandOutput>(),
+                Arg.Any<CompressionOptions>())
+            .Returns(CompressionResult.From(
+                compressedFallback,
+                10,
+                3,
+                "package-manager",
+                [],
+                false));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript(executable, resolvedCommand));
+        var jestFilter = BuiltInFilters.All.Single(candidate => candidate.Id == "jest");
+        var universal = BuiltInFilters.All.Single(candidate => candidate.Id == "ansi-strip");
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([jestFilter, universal]);
+        var realFilterEngine = new FilterEngine();
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(jestFilter, Arg.Any<string>())
+            .Returns(ci => realFilterEngine.Apply(jestFilter, ci.ArgAt<string>(1)));
+        filterEngine.Apply(universal, Arg.Any<string>())
+            .Returns(ci => realFilterEngine.Apply(universal, ci.ArgAt<string>(1)));
+        var service = MakeService(
+            runner: runner,
+            compressor: compressor,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default with { ShowCompressionMetadata = false },
+            CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Equal(0, result.Value.ExitCode);
+        Assert.Equal("jest: ok", result.Value.Text);
+        filterEngine.Received(1).Apply(jestFilter, "");
+        filterEngine.DidNotReceive().Apply(universal, Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task RunBufferedAsync_ResolvedFilterWithoutMerge_UsesCombinedStreamWithoutAppendingRawStderr()
+    {
+        const string stdout = "FAIL checkout reports the underlying assertion";
+        const string filtered = "checkout: failed";
+        const string stderr = "fatal: test worker exited with code 1";
+        var rawCombined = stdout + "\n" + stderr;
+        var invocation = CommandInvocation.Buffered("pnpm", ["test"], "pnpm test");
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured(stdout, stderr, 1, TimeSpan.Zero)));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript("jest", "jest --runInBand"));
+        var filter = new CompiledFilterDefinition
+        {
+            Id = "jest",
+            AppliesTo = ["jest"],
+            MergeStderr = false,
+            Stages = [],
+        };
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([filter]);
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(filter, Arg.Any<string>())
+            .Returns(new FilterResult(filtered, filter.Id, 1));
+        var service = MakeService(
+            runner: runner,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default with { ShowCompressionMetadata = false },
+            CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Equal(1, result.Value.ExitCode);
+        Assert.Equal(filtered, result.Value.Text);
+        Assert.DoesNotContain(stderr, result.Value.Text);
+        Assert.DoesNotContain("command timed out", result.Value.Text);
+        filterEngine.Received(1).Apply(filter, rawCombined);
+    }
+
+    [Fact]
+    public async Task RunBufferedAsync_ResolvedSpecificFilter_PreservesIdenticalCrossStreamLineMultiplicity()
+    {
+        const string repeatedLine = "FAIL checkout reports the same worker diagnostic";
+        var rawCombined = repeatedLine + "\n" + repeatedLine;
+        var invocation = CommandInvocation.Buffered("pnpm", ["test"], "pnpm test");
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured(repeatedLine, repeatedLine, 1, TimeSpan.Zero)));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript("jest", "jest --runInBand"));
+        var filter = new CompiledFilterDefinition
+        {
+            Id = "jest",
+            AppliesTo = ["jest"],
+            MergeStderr = false,
+            Stages = [],
+        };
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([filter]);
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(filter, Arg.Any<string>())
+            .Returns(ci => new FilterResult(ci.ArgAt<string>(1), filter.Id, 1));
+        var service = MakeService(
+            runner: runner,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default with { ShowCompressionMetadata = false },
+            CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Equal(rawCombined, result.Value.Text);
+        Assert.Equal(2, Regex.Matches(result.Value.Text, Regex.Escape(repeatedLine)).Count);
+        filterEngine.Received(1).Apply(filter, rawCombined);
+    }
+
+    [Fact]
+    public async Task RunBufferedAsync_TimedOutResolvedMergeFilter_PreservesDiagnosticAfterFilteringExactlyOnce()
+    {
+        const string stdout = "PASS checkout completes";
+        const string filteredStdout = "checkout: passed";
+        const string stderr = "warning: worker exited after completing the test";
+        const string timeoutDiagnostic =
+            "[hypa: command timed out after 30s; killed process; exit=124; elapsed=31s]";
+        var rawCombined = stdout + "\n" + stderr;
+        var invocation = CommandInvocation.Buffered("pnpm", ["test"], "pnpm test");
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.CreateTimedOut(TimeSpan.FromSeconds(31), stdout, stderr)));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript("jest", "jest --runInBand"));
+        var filter = new CompiledFilterDefinition
+        {
+            Id = "jest-merged",
+            AppliesTo = ["jest"],
+            MergeStderr = true,
+            Stages = [],
+        };
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([filter]);
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(filter, Arg.Any<string>())
+            .Returns(ci =>
+            {
+                var text = ci.ArgAt<string>(1)
+                    .Replace(stdout, filteredStdout, StringComparison.Ordinal)
+                    .Replace(timeoutDiagnostic, string.Empty, StringComparison.Ordinal)
+                    .TrimEnd();
+                return new FilterResult(text, filter.Id, 1);
+            });
+        var service = MakeService(
+            runner: runner,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default with { ShowCompressionMetadata = false },
+            CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Equal(CommandOutput.TimeoutExitCode, result.Value.ExitCode);
+        Assert.Equal(filteredStdout + "\n" + stderr + "\n" + timeoutDiagnostic, result.Value.Text);
+        Assert.DoesNotContain(stdout, result.Value.Text);
+        Assert.Single(Regex.Matches(result.Value.Text, Regex.Escape(stderr)));
+        Assert.Single(Regex.Matches(result.Value.Text, Regex.Escape(timeoutDiagnostic)));
+        filterEngine.Received(1).Apply(filter, rawCombined);
+    }
+
+    [Fact]
+    public async Task RunBufferedAsync_ResolvedMergeFilter_ReceivesExactRawCombinedStreamBeforeLossyCompression()
+    {
+        var stdout = "raw stdout header\n" + new string('s', 300);
+        var stderr = "raw stderr diagnostic\n" + new string('e', 300);
+        var rawCombined = stdout + "\n" + stderr;
+        var invocation = CommandInvocation.Buffered("pnpm", ["test"], "pnpm test");
+        var captured = CommandOutput.Captured(stdout, stderr, 1, TimeSpan.Zero);
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(captured));
+
+        var compressor = Substitute.For<IOutputCompressor>();
+        compressor.Id.Returns("lossy-package-manager");
+        compressor.CanHandle(Arg.Any<CommandInvocation>()).Returns(true);
+        compressor.Compress(
+                Arg.Any<CommandInvocation>(),
+                Arg.Any<CommandOutput>(),
+                Arg.Any<CompressionOptions>())
+            .Returns(CompressionResult.From(
+                "lossy compressed package output",
+                200,
+                3,
+                "lossy-package-manager",
+                [],
+                false));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript("jest", "jest --runInBand"));
+        var filter = new CompiledFilterDefinition
+        {
+            Id = "jest-merged",
+            AppliesTo = ["jest"],
+            MergeStderr = true,
+            Stages = [],
+        };
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([filter]);
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(filter, Arg.Any<string>())
+            .Returns(ci => new FilterResult(ci.ArgAt<string>(1), filter.Id, 1));
+        var service = MakeService(
+            runner: runner,
+            compressor: compressor,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default with { ShowCompressionMetadata = false },
+            CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Equal(rawCombined, result.Value.Text);
+        Assert.Single(Regex.Matches(result.Value.Text, Regex.Escape(stderr)));
+        compressor.Received(1).Compress(
+            invocation,
+            captured,
+            Arg.Any<CompressionOptions>());
+        filterEngine.Received(1).Apply(filter, rawCombined);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RunBufferedAsync_ResolvedFilterFallsBackToCompressedOutput_WhenNoStageAppliesOrFilterVoids(
+        bool filterVoids)
+    {
+        const string compressedOutput = "compressed package-manager output";
+        var rawOutput = string.Join(
+            '\n',
+            Enumerable.Range(1, 100).Select(line => $"raw package-script output {line}"));
+        var invocation = CommandInvocation.Buffered("pnpm", ["test"], "pnpm test");
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured(rawOutput, "", 1, TimeSpan.Zero)));
+
+        var compressor = Substitute.For<IOutputCompressor>();
+        compressor.Id.Returns("pkg-manager");
+        compressor.CanHandle(Arg.Any<CommandInvocation>()).Returns(true);
+        compressor.Compress(
+                Arg.Any<CommandInvocation>(),
+                Arg.Any<CommandOutput>(),
+                Arg.Any<CompressionOptions>())
+            .Returns(CompressionResult.From(
+                compressedOutput,
+                1_000,
+                8,
+                "pkg-manager",
+                ["parse-errors"],
+                false));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript("jest", "jest --runInBand"));
+        var filter = new CompiledFilterDefinition
+        {
+            Id = "jest",
+            AppliesTo = ["jest"],
+            MatchCommand = @"^jest\s+--runInBand$",
+            CompiledMatchCommand = new Regex(@"^jest\s+--runInBand$", RegexOptions.CultureInvariant),
+            Stages = [],
+        };
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([filter]);
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(filter, Arg.Any<string>())
+            .Returns(filterVoids
+                ? new FilterResult("", filter.Id, 1)
+                : new FilterResult(rawOutput, filter.Id, 0));
+        var service = MakeService(
+            runner: runner,
+            compressor: compressor,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+        var options = CompressionOptions.Default with { ShowCompressionMetadata = false };
+
+        var result = await service.RunBufferedAsync(invocation, options, CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Equal(compressedOutput, result.Value.Text);
+        filterEngine.Received(1).Apply(filter, rawOutput);
+    }
+
+    [Fact]
+    public async Task RunBufferedAsync_ResolvedUnsupportedTool_AppliesUniversalFilterToCompressedOutput()
+    {
+        const string compressedOutput = "\x1B[31mcompressed package-manager output\x1B[0m";
+        var rawOutput = string.Join(
+            '\n',
+            Enumerable.Range(1, 100).Select(line => $"raw unsupported-tool output {line}"));
+        var invocation = CommandInvocation.Buffered("pnpm", ["unsupported"], "pnpm unsupported");
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured(rawOutput, "", 1, TimeSpan.Zero)));
+
+        var compressor = Substitute.For<IOutputCompressor>();
+        compressor.Id.Returns("pkg-manager");
+        compressor.CanHandle(Arg.Any<CommandInvocation>()).Returns(true);
+        compressor.Compress(
+                Arg.Any<CommandInvocation>(),
+                Arg.Any<CommandOutput>(),
+                Arg.Any<CompressionOptions>())
+            .Returns(CompressionResult.From(
+                compressedOutput,
+                1_000,
+                8,
+                "pkg-manager",
+                [],
+                false));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript("unsupported-tool", "unsupported-tool --flag"));
+        var universal = BuiltInFilters.All.Single(filter => filter.Id == "ansi-strip");
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([universal]);
+        var realFilterEngine = new FilterEngine();
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(universal, Arg.Any<string>())
+            .Returns(ci => realFilterEngine.Apply(universal, ci.ArgAt<string>(1)));
+        var service = MakeService(
+            runner: runner,
+            compressor: compressor,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default with { ShowCompressionMetadata = false },
+            CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Equal("compressed package-manager output", result.Value.Text);
+        Assert.DoesNotContain("raw unsupported-tool output", result.Value.Text);
+        filterEngine.Received(1).Apply(universal, compressedOutput);
+        filterEngine.DidNotReceive().Apply(universal, rawOutput);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task RunBufferedAsync_ResolvedPassthrough_AppliesUniversalFilterToExactCombinedDiagnostics(
+        bool smallOutput)
+    {
+        const string repeatedDiagnostic = "fatal: package script worker exited with code 1";
+        const string stdout = "package script failed\n" + repeatedDiagnostic;
+        const string stderr = repeatedDiagnostic + "\n" + repeatedDiagnostic;
+        const string timeoutDiagnostic =
+            "[hypa: command timed out after 30s; killed process; exit=124; elapsed=31s]";
+        var expectedCombined = stdout + "\n" + stderr + "\n" + timeoutDiagnostic;
+        var invocation = CommandInvocation.Buffered("pnpm", ["unsupported"], "pnpm unsupported");
+        var output = CommandOutput.CreateTimedOut(TimeSpan.FromSeconds(31), stdout, stderr);
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(output));
+
+        var tokenCounter = Substitute.For<ITokenCounter>();
+        tokenCounter.EstimateTokens(Arg.Any<string>()).Returns(100);
+        var compressor = Substitute.For<IOutputCompressor>();
+        compressor.Id.Returns("pkg-manager");
+        compressor.CanHandle(Arg.Any<CommandInvocation>()).Returns(true);
+        compressor.Compress(
+                Arg.Any<CommandInvocation>(),
+                Arg.Any<CommandOutput>(),
+                Arg.Any<CompressionOptions>())
+            .Returns(CompressionResult.From(
+                "discarded compressor candidate",
+                100,
+                100,
+                "pkg-manager",
+                [],
+                false));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript("unsupported-tool", "unsupported-tool --flag"));
+        var universal = new CompiledFilterDefinition
+        {
+            Id = "universal",
+            AppliesTo = [],
+            Stages = [],
+        };
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([universal]);
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(universal, Arg.Any<string>())
+            .Returns(ci => new FilterResult(ci.ArgAt<string>(1), universal.Id, 1));
+        var service = MakeService(
+            runner: runner,
+            compressor: compressor,
+            tokenCounter: tokenCounter,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default with
+            {
+                SmallOutputThreshold = smallOutput ? 100 : 0,
+                ShowCompressionMetadata = false,
+            },
+            CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Equal(expectedCombined, result.Value.Text);
+        Assert.Equal(3, Regex.Matches(result.Value.Text, Regex.Escape(repeatedDiagnostic)).Count);
+        Assert.Single(Regex.Matches(result.Value.Text, Regex.Escape(timeoutDiagnostic)));
+        filterEngine.Received(1).Apply(universal, expectedCombined);
+    }
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RunBufferedAsync_ResolvedUniversalFilter_TransformsComposedFallbackDiagnosticsExactlyOnce(
+        bool timedOut)
+    {
+        const string decoratedStderrLine = "\x1B[31mfatal: package script failed\x1B[0m";
+        const string plainStderrLine = "fatal: package script failed";
+        const string stderr = decoratedStderrLine + "\n" + decoratedStderrLine;
+        const string timeoutDiagnostic =
+            "[hypa: command timed out after 30s; killed process; exit=124; elapsed=31s]";
+        const string compressedOutput = "compressed package-manager output";
+        const string filteredFallback = "compressed package-manager output\n" +
+            plainStderrLine + "\n" + plainStderrLine;
+        var rawOutput = string.Join(
+            '\n',
+            Enumerable.Range(1, 100).Select(line => $"raw unsupported-tool output {line}"));
+        var invocation = CommandInvocation.Buffered("pnpm", ["unsupported"], "pnpm unsupported");
+        var output = timedOut
+            ? CommandOutput.CreateTimedOut(TimeSpan.FromSeconds(31), rawOutput, stderr)
+            : CommandOutput.Captured(rawOutput, stderr, 1, TimeSpan.FromSeconds(31));
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(output));
+
+        var compressor = Substitute.For<IOutputCompressor>();
+        compressor.Id.Returns("pkg-manager");
+        compressor.CanHandle(Arg.Any<CommandInvocation>()).Returns(true);
+        compressor.Compress(
+                Arg.Any<CommandInvocation>(),
+                Arg.Any<CommandOutput>(),
+                Arg.Any<CompressionOptions>())
+            .Returns(CompressionResult.From(
+                compressedOutput,
+                1_000,
+                8,
+                "pkg-manager",
+                [],
+                false));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript("unsupported-tool", "unsupported-tool --flag"));
+        var universal = BuiltInFilters.All.Single(filter => filter.Id == "ansi-strip");
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([universal]);
+        var realFilterEngine = new FilterEngine();
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(universal, Arg.Any<string>())
+            .Returns(ci => realFilterEngine.Apply(universal, ci.ArgAt<string>(1)));
+        var service = MakeService(
+            runner: runner,
+            compressor: compressor,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default with { ShowCompressionMetadata = false },
+            CancellationToken.None);
+
+        var composedFallback = compressedOutput + "\n" + stderr +
+            (timedOut ? "\n" + timeoutDiagnostic : string.Empty);
+        var expected = filteredFallback +
+            (timedOut ? "\n" + timeoutDiagnostic : string.Empty);
+        Assert.True(result.IsOk);
+        Assert.Equal(expected, result.Value.Text);
+        Assert.Equal(timedOut ? CommandOutput.TimeoutExitCode : 1, result.Value.ExitCode);
+        Assert.DoesNotContain('\u001b', result.Value.Text);
+        Assert.Equal(2, Regex.Matches(result.Value.Text, Regex.Escape(plainStderrLine)).Count);
+        Assert.Equal(
+            timedOut ? 1 : 0,
+            Regex.Matches(result.Value.Text, Regex.Escape(timeoutDiagnostic)).Count);
+        filterEngine.Received(1).Apply(universal, composedFallback);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task RunBufferedAsync_ResolvedRejectedSpecificFilter_FallsBackToCompressedOutputAndPreservesDiagnosticsExactlyOnce(
+        bool timedOut,
+        bool filterVoids)
+    {
+        const string retainedStderrLine = "fatal: package script failed after producing its report";
+        const string missingStderrLine = "caused by: test worker exited with code 1";
+        const string stderr = retainedStderrLine + "\n" + missingStderrLine;
+        const string compressedOutput = "compressed package-manager output\n" + retainedStderrLine;
+        const string timeoutDiagnostic =
+            "[hypa: command timed out after 30s; killed process; exit=124; elapsed=31s]";
+        var rawOutput = string.Join(
+            '\n',
+            Enumerable.Range(1, 100).Select(line => $"raw package-script output {line}"));
+        var rawCombined = rawOutput + "\n" + stderr;
+        var invocation = CommandInvocation.Buffered("pnpm", ["test"], "pnpm test");
+        var output = timedOut
+            ? CommandOutput.CreateTimedOut(TimeSpan.FromSeconds(31), rawOutput, stderr)
+            : CommandOutput.Captured(rawOutput, stderr, 1, TimeSpan.FromSeconds(31));
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(output));
+
+        var compressor = Substitute.For<IOutputCompressor>();
+        compressor.Id.Returns("pkg-manager");
+        compressor.CanHandle(Arg.Any<CommandInvocation>()).Returns(true);
+        compressor.Compress(
+                Arg.Any<CommandInvocation>(),
+                Arg.Any<CommandOutput>(),
+                Arg.Any<CompressionOptions>())
+            .Returns(CompressionResult.From(
+                compressedOutput,
+                1_000,
+                8,
+                "pkg-manager",
+                [],
+                false));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns(new ResolvedPackageScript("jest", "jest --runInBand"));
+        var filter = new CompiledFilterDefinition
+        {
+            Id = "jest",
+            AppliesTo = ["jest"],
+            MatchCommand = @"^jest\s+--runInBand$",
+            CompiledMatchCommand = new Regex(@"^jest\s+--runInBand$", RegexOptions.CultureInvariant),
+            Stages = [],
+        };
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([filter]);
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(filter, Arg.Any<string>())
+            .Returns(filterVoids
+                ? new FilterResult("", filter.Id, 1)
+                : new FilterResult(rawCombined, filter.Id, 0));
+        var service = MakeService(
+            runner: runner,
+            compressor: compressor,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default with { ShowCompressionMetadata = false },
+            CancellationToken.None);
+
+        var expected = compressedOutput + "\n" + missingStderrLine +
+            (timedOut ? "\n" + timeoutDiagnostic : string.Empty);
+        Assert.True(result.IsOk);
+        Assert.Equal(expected, result.Value.Text);
+        Assert.Equal(timedOut ? CommandOutput.TimeoutExitCode : 1, result.Value.ExitCode);
+        Assert.DoesNotContain("raw package-script output", result.Value.Text);
+        Assert.Single(Regex.Matches(result.Value.Text, Regex.Escape(stderr)));
+        Assert.Single(Regex.Matches(result.Value.Text, Regex.Escape(retainedStderrLine)));
+        Assert.Single(Regex.Matches(result.Value.Text, Regex.Escape(missingStderrLine)));
+        Assert.Equal(
+            timedOut ? 1 : 0,
+            Regex.Matches(result.Value.Text, Regex.Escape(timeoutDiagnostic)).Count);
+        filterEngine.Received(1).Apply(filter, rawCombined);
+    }
+
+    [Fact]
+    public async Task RunBufferedAsync_UnresolvedBuiltIn_UsesOriginalPairForFilter()
+    {
+        var invocation = CommandInvocation.Buffered("pnpm", ["install"], "pnpm install");
+        var runner = Substitute.For<ICommandRunner>();
+        runner.RunAsync(Arg.Any<CommandInvocation>(), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured(new string('x', 400), "", 0, TimeSpan.Zero)));
+
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
+        packageScriptResolver.TryResolve(invocation)
+            .Returns((ResolvedPackageScript?)null);
+
+        var installFilter = new CompiledFilterDefinition
+        {
+            Id = "pnpm-install",
+            AppliesTo = ["pnpm"],
+            MatchCommand = @"^pnpm\s+install\b",
+            CompiledMatchCommand = new Regex(@"^pnpm\s+install\b", RegexOptions.CultureInvariant),
+            Stages = [],
+        };
+        var filterRepo = Substitute.For<IFilterRepository>();
+        filterRepo.GetAll().Returns([installFilter]);
+        var filterEngine = Substitute.For<IFilterEngine>();
+        filterEngine.Apply(installFilter, Arg.Any<string>())
+            .Returns(new FilterResult("pnpm-install-filtered", installFilter.Id, 1));
+
+        var service = MakeService(
+            runner: runner,
+            filterRepo: filterRepo,
+            filterEngine: filterEngine,
+            packageScriptResolver: packageScriptResolver);
+
+        var result = await service.RunBufferedAsync(
+            invocation,
+            CompressionOptions.Default,
+            CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.Contains("pnpm-install-filtered", result.Value.Text);
+        packageScriptResolver.Received(1).TryResolve(invocation);
+        filterEngine.Received(1).Apply(installFilter, Arg.Any<string>());
     }
 
     [Fact]

--- a/tests/Hypa.UnitTests/Application/PackageManagerScriptResolverTests.cs
+++ b/tests/Hypa.UnitTests/Application/PackageManagerScriptResolverTests.cs
@@ -1,0 +1,655 @@
+using System.Text.Json;
+using Hypa.Infrastructure.Rewrite;
+using Hypa.Runtime.Application.Ports;
+using Hypa.Runtime.Application.Services;
+using Hypa.Runtime.Domain.Runner;
+using NSubstitute;
+using Xunit;
+
+namespace Hypa.UnitTests.Application;
+
+public sealed class PackageManagerScriptResolverTests
+{
+    private const string WorkingDirectory = "/workspace/project";
+
+    private readonly IFileSystem _fileSystem = Substitute.For<IFileSystem>();
+    private readonly PackageManagerScriptResolver _resolver;
+
+    public PackageManagerScriptResolverTests()
+    {
+        _resolver = new PackageManagerScriptResolver(_fileSystem, new ShellLexer());
+    }
+
+    [Theory]
+    [InlineData("pnpm", "check", "biome check .", "biome")]
+    [InlineData("yarn", "format", "prettier --write .", "prettier")]
+    public void TryResolve_DirectCustomScript_ReturnsExactResolvedScript(
+        string packageManager,
+        string scriptName,
+        string scriptCommand,
+        string expectedExecutable)
+    {
+        ConfigureScripts((scriptName, scriptCommand));
+
+        var resolved = Resolve(packageManager, [scriptName], $"{packageManager} {scriptName}");
+
+        Assert.Equal(new ResolvedPackageScript(expectedExecutable, scriptCommand), resolved);
+    }
+
+    [Fact]
+    public void TryResolve_NpmDirectCustomScript_ReturnsNull()
+    {
+        ConfigureScripts(("lint", "eslint ."));
+
+        var resolved = _resolver.TryResolve(Invocation("npm", ["lint"], "npm lint"));
+
+        Assert.Null(resolved);
+    }
+
+    [Theory]
+    [InlineData("npm", "run")]
+    [InlineData("npm", "run-script")]
+    [InlineData("npm", "rum")]
+    [InlineData("npm", "urn")]
+    [InlineData("pnpm", "run")]
+    [InlineData("yarn", "run")]
+    [InlineData("pnpm", "run-script")]
+    [InlineData("yarn", "run-script")]
+    public void TryResolve_ExplicitRunForm_ReturnsExactResolvedScript(
+        string packageManager,
+        string runCommand)
+    {
+        const string scriptCommand = "eslint --max-warnings 0 .";
+        ConfigureScripts(("lint", scriptCommand));
+
+        var resolved = Resolve(
+            packageManager,
+            [runCommand, "lint"],
+            $"{packageManager} {runCommand} lint");
+
+        Assert.Equal(new ResolvedPackageScript("eslint", scriptCommand), resolved);
+    }
+
+    [Theory]
+    [InlineData("test", "test")]
+    [InlineData("t", "test")]
+    [InlineData("tst", "test")]
+    [InlineData("start", "start")]
+    [InlineData("stop", "stop")]
+    [InlineData("restart", "restart")]
+    public void TryResolve_NpmLifecycleShorthandOrTestAlias_ResolvesCanonicalScript(
+        string invocationCommand,
+        string scriptName)
+    {
+        const string scriptCommand = "node lifecycle.js";
+        ConfigureScripts((scriptName, scriptCommand));
+
+        var resolved = Resolve("npm", [invocationCommand], $"npm {invocationCommand}");
+
+        Assert.Equal(new ResolvedPackageScript("node", scriptCommand), resolved);
+    }
+
+    [Theory]
+    [InlineData("t")]
+    [InlineData("tst")]
+    public void TryResolve_PnpmTestAlias_ResolvesTestScript(string invocationCommand)
+    {
+        const string scriptCommand = "vitest run";
+        ConfigureScripts(("test", scriptCommand));
+
+        var resolved = Resolve("pnpm", [invocationCommand], $"pnpm {invocationCommand}");
+
+        Assert.Equal(new ResolvedPackageScript("vitest", scriptCommand), resolved);
+    }
+
+    [Theory]
+    [InlineData("eslint .", "eslint")]
+    [InlineData("biome check .", "biome")]
+    [InlineData("oxlint src", "oxlint")]
+    [InlineData("jest --runInBand", "jest")]
+    [InlineData("vitest run --coverage", "vitest")]
+    [InlineData("tsc --noEmit", "tsc")]
+    public void TryResolve_RecognizesToolLeadExecutables(string scriptCommand, string expectedExecutable)
+    {
+        ConfigureScripts(("verify", scriptCommand));
+
+        var resolved = Resolve("pnpm", ["verify"], "pnpm verify");
+
+        Assert.Equal(expectedExecutable, resolved.Executable);
+        Assert.Equal(scriptCommand, resolved.Command);
+    }
+
+    [Theory]
+    [InlineData("/opt/homebrew/bin/npm", "/workspace/project/node_modules/.bin/eslint", "eslint", "eslint")]
+    [InlineData("/usr/local/bin/pnpm.cmd", "./node_modules/.bin/biome.cmd check .", "biome", "biome check .")]
+    [InlineData("C:/Program Files/nodejs/yarn.exe", "C:/workspace/node_modules/.bin/oxlint.exe src", "oxlint", "oxlint src")]
+    [InlineData(@"C:\Program Files\nodejs\npm.cmd", @"C:\workspace\project\node_modules\.bin\eslint.cmd --fix .", "eslint", "eslint --fix .")]
+    [InlineData(@"C:\Program Files\nodejs\NpM.BaT", "./node_modules/.bin/eslint --fix .", "eslint", "eslint --fix .")]
+    [InlineData("npm", @"C:\workspace\project\node_modules\.bin\EsLiNt.BaT --cache .", "eslint", "eslint --cache .")]
+    public void TryResolve_NormalizesPackageManagerAndReturnsCanonicalMatchCommand(
+        string packageManagerExecutable,
+        string scriptCommand,
+        string expectedExecutable,
+        string expectedCommand)
+    {
+        ConfigureScripts(("lint", scriptCommand));
+
+        var resolved = Resolve(
+            packageManagerExecutable,
+            ["run", "lint"],
+            "package-manager run lint");
+
+        Assert.Equal(new ResolvedPackageScript(expectedExecutable, expectedCommand), resolved);
+    }
+
+    [Fact]
+    public void TryResolve_ArbitraryScriptExtension_PreservesExtension()
+    {
+        const string scriptCommand = "./node_modules/.bin/eslint.js --fix .";
+        ConfigureScripts(("lint", scriptCommand));
+
+        var resolved = Resolve("npm", ["run", "lint"], "npm run lint");
+
+        Assert.Equal(new ResolvedPackageScript("eslint.js", "eslint.js --fix ."), resolved);
+    }
+
+    [Fact]
+    public void TryResolve_QuotedLeadExecutable_ReturnsCanonicalMatchCommandWithArguments()
+    {
+        const string scriptCommand = "\"./node_modules/.bin/eslint.cmd\" --fix .";
+        ConfigureScripts(("lint", scriptCommand));
+
+        var resolved = Resolve("npm", ["run", "lint"], "npm run lint");
+
+        Assert.Equal("eslint", resolved.Executable);
+        Assert.Equal("eslint --fix .", resolved.Command);
+    }
+
+    [Theory]
+    [InlineData("\"eslint\"-wrapper .")]
+    [InlineData("es\"lint\" .")]
+    [InlineData("\"es\"\"lint\" .")]
+    public void TryResolve_CompoundQuotedLeadShellWord_ReturnsNull(string scriptCommand)
+    {
+        ConfigureScripts(("lint", scriptCommand));
+
+        var resolved = _resolver.TryResolve(Invocation("npm", ["run", "lint"], "npm run lint"));
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void TryResolve_ChainedScript_UsesFirstExecutableAndReturnsEntireCommand()
+    {
+        const string scriptCommand = "vitest run && tsc --noEmit";
+        ConfigureScripts(("verify", scriptCommand));
+
+        var resolved = Resolve("yarn", ["verify"], "yarn verify");
+
+        Assert.Equal("vitest", resolved.Executable);
+        Assert.Equal(scriptCommand, resolved.Command);
+    }
+
+    [Theory]
+    [InlineData("NODE_ENV=\"test mode\" ./node_modules/.bin/vitest run", "vitest run")]
+    [InlineData("NODE_ENV=test CI=1 ./node_modules/.bin/vitest run", "vitest run")]
+    public void TryResolve_AssignmentPrefixedScript_UsesHostPackageScriptSemantics(
+        string scriptCommand,
+        string expectedCommand)
+    {
+        ConfigureScripts(("test:ci", scriptCommand));
+
+        var resolved = _resolver.TryResolve(Invocation("pnpm", ["test:ci"], "pnpm test:ci"));
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Null(resolved);
+            return;
+        }
+
+        Assert.Equal(new ResolvedPackageScript("vitest", expectedCommand), resolved);
+    }
+
+    [Theory]
+    [InlineData("&& eslint .")]
+    [InlineData("| eslint .")]
+    [InlineData("> output.txt")]
+    [InlineData("& eslint .")]
+    public void TryResolve_ScriptBeginningWithControlToken_ReturnsNull(string scriptCommand)
+    {
+        ConfigureScripts(("lint", scriptCommand));
+
+        var resolved = _resolver.TryResolve(Invocation("npm", ["run", "lint"], "npm run lint"));
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void TryResolve_ReadsPackageJsonFromInvocationWorkingDirectory()
+    {
+        const string invocationDirectory = "/workspace/packages/web";
+        const string fallbackDirectory = "/unrelated/current-directory";
+        var expectedPath = PackageJsonPath(invocationDirectory);
+        _fileSystem.GetCurrentDirectory().Returns(fallbackDirectory);
+        ConfigureScripts(invocationDirectory, ("lint", "eslint ."));
+
+        var resolved = Resolve(
+            "pnpm",
+            ["lint"],
+            "pnpm lint",
+            workingDirectory: invocationDirectory);
+
+        Assert.Equal("eslint", resolved.Executable);
+        Assert.Equal("eslint .", resolved.Command);
+        _fileSystem.Received().FileExists(expectedPath);
+        _fileSystem.Received().ReadAllText(expectedPath);
+        _fileSystem.DidNotReceive().ReadAllText(PackageJsonPath(fallbackDirectory));
+    }
+
+    [Fact]
+    public void TryResolve_WithoutInvocationWorkingDirectory_UsesFileSystemCurrentDirectory()
+    {
+        const string currentDirectory = "/workspace/current";
+        _fileSystem.GetCurrentDirectory().Returns(currentDirectory);
+        ConfigureScripts(currentDirectory, ("test", "vitest run"));
+
+        var resolved = Resolve("npm", ["test"], "npm test", workingDirectory: null);
+
+        Assert.Equal("vitest", resolved.Executable);
+        Assert.Equal("vitest run", resolved.Command);
+        _fileSystem.Received().ReadAllText(PackageJsonPath(currentDirectory));
+    }
+
+    [Theory]
+    [InlineData("npm", "install")]
+    [InlineData("npm", "ci")]
+    [InlineData("pnpm", "add")]
+    [InlineData("yarn", "remove")]
+    [InlineData("pnpm", "exec")]
+    [InlineData("yarn", "publish")]
+    [InlineData("npm", "i")]
+    [InlineData("npm", "x")]
+    [InlineData("pnpm", "i")]
+    [InlineData("pnpm", "x")]
+    [InlineData("yarn", "i")]
+    [InlineData("yarn", "x")]
+    [InlineData("pnpm", "c")]
+    [InlineData("pnpm", "self-update")]
+    [InlineData("pnpm", "unpublish")]
+    [InlineData("pnpm", "it")]
+    [InlineData("yarn", "lockfile")]
+    [InlineData("yarn", "prune")]
+    [InlineData("yarn", "self-update")]
+    [InlineData("yarn", "patch-commit")]
+    public void TryResolve_KnownBuiltIn_DoesNotReinterpretAsScript(
+        string packageManager,
+        string builtInCommand)
+    {
+        ConfigureScripts((builtInCommand, "eslint ."));
+
+        var resolved = _resolver.TryResolve(Invocation(
+            packageManager,
+            [builtInCommand],
+            $"{packageManager} {builtInCommand}"));
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void TryResolve_ExplicitPnpmRunOfCAliasNamedScript_ResolvesScript()
+    {
+        const string scriptCommand = "node clean.js";
+        ConfigureScripts(("c", scriptCommand));
+
+        var resolved = Resolve("pnpm", ["run", "c"], "pnpm run c");
+
+        Assert.Equal(new ResolvedPackageScript("node", scriptCommand), resolved);
+    }
+
+    [Theory]
+    [InlineData("pnpm", "it")]
+    [InlineData("yarn", "prune")]
+    [InlineData("yarn", "patch-commit")]
+    public void TryResolve_ExplicitRunOfNewlyReservedCommand_ResolvesScript(
+        string packageManager,
+        string scriptName)
+    {
+        const string scriptCommand = "node script.js";
+        ConfigureScripts((scriptName, scriptCommand));
+
+        var resolved = Resolve(
+            packageManager,
+            ["run", scriptName],
+            $"{packageManager} run {scriptName}");
+
+        Assert.Equal(new ResolvedPackageScript("node", scriptCommand), resolved);
+    }
+
+    [Theory]
+    [InlineData("npm", "run")]
+    [InlineData("npm", "run-script")]
+    [InlineData("pnpm", "run")]
+    [InlineData("yarn", "run")]
+    [InlineData("pnpm", "run-script")]
+    [InlineData("yarn", "run-script")]
+    public void TryResolve_ExplicitRunOfBuiltInNamedScript_ResolvesScript(
+        string packageManager,
+        string runCommand)
+    {
+        const string scriptCommand = "node install.js";
+        ConfigureScripts(("install", scriptCommand));
+
+        var resolved = Resolve(
+            packageManager,
+            [runCommand, "install"],
+            $"{packageManager} {runCommand} install");
+
+        Assert.Equal(new ResolvedPackageScript("node", scriptCommand), resolved);
+    }
+
+    [Theory]
+    [InlineData("npm", "run")]
+    [InlineData("npm", "run-script")]
+    [InlineData("pnpm", "run")]
+    [InlineData("yarn", "run")]
+    [InlineData("pnpm", "run-script")]
+    [InlineData("yarn", "run-script")]
+    public void TryResolve_RunWithoutScriptName_DoesNotResolve(
+        string packageManager,
+        string runCommand)
+    {
+        ConfigureScripts((runCommand, "eslint ."));
+
+        var resolved = _resolver.TryResolve(Invocation(
+            packageManager,
+            [runCommand],
+            $"{packageManager} {runCommand}"));
+
+        Assert.Null(resolved);
+    }
+
+    [Theory]
+    [InlineData("--silent")]
+    [InlineData("-s")]
+    public void TryResolve_SafeLeadingSilentOptionBeforeExplicitRun_ResolvesScript(string option)
+    {
+        const string scriptCommand = "eslint .";
+        ConfigureScripts(("lint", scriptCommand));
+
+        var resolved = Resolve(
+            "npm",
+            [option, "run", "lint"],
+            $"npm {option} run lint");
+
+        Assert.Equal(new ResolvedPackageScript("eslint", scriptCommand), resolved);
+    }
+
+    [Theory]
+    [InlineData("--silent")]
+    [InlineData("-s")]
+    public void TryResolve_SafeSilentOptionAfterExplicitRun_ResolvesScript(string option)
+    {
+        const string scriptCommand = "eslint .";
+        ConfigureScripts(("lint", scriptCommand));
+
+        var resolved = Resolve(
+            "npm",
+            ["run", option, "lint"],
+            $"npm run {option} lint");
+
+        Assert.Equal(new ResolvedPackageScript("eslint", scriptCommand), resolved);
+    }
+
+    [Fact]
+    public void TryResolve_UnknownLeadingOption_ReturnsNull()
+    {
+        ConfigureScripts(("lint", "eslint ."));
+
+        var resolved = _resolver.TryResolve(Invocation(
+            "npm",
+            ["--future-option", "run", "lint"],
+            "npm --future-option run lint"));
+
+        Assert.Null(resolved);
+    }
+
+    [Theory]
+    [InlineData("npm", "--registry", "https://registry.example.test")]
+    [InlineData("npm", "--prefix", "/workspace/other")]
+    [InlineData("npm", "--workspace", "web")]
+    [InlineData("pnpm", "--dir", "/workspace/other")]
+    [InlineData("yarn", "--cwd", "/workspace/other")]
+    public void TryResolve_ValueTakingOrTargetingLeadingOption_ReturnsNull(
+        string packageManager,
+        string option,
+        string value)
+    {
+        ConfigureScripts(("lint", "eslint ."));
+
+        var resolved = _resolver.TryResolve(Invocation(
+            packageManager,
+            [option, value, "run", "lint"],
+            $"{packageManager} {option} {value} run lint"));
+
+        Assert.Null(resolved);
+    }
+
+    [Theory]
+    [InlineData("--workspace", "web")]
+    [InlineData("--workspace=web", null)]
+    [InlineData("-w", "web")]
+    [InlineData("-w=web", null)]
+    [InlineData("--workspaces", null)]
+    [InlineData("--workspaces=web", null)]
+    [InlineData("--ws", null)]
+    [InlineData("--ws=web", null)]
+    [InlineData("-ws", null)]
+    [InlineData("-ws=web", null)]
+    [InlineData("--prefix", "/workspace/other")]
+    [InlineData("--prefix=/workspace/other", null)]
+    [InlineData("-C", "/workspace/other")]
+    [InlineData("-C=/workspace/other", null)]
+    public void TryResolve_NpmTargetingOptionBeforePassThroughSeparator_ReturnsNull(
+        string targetingOption,
+        string? targetingValue)
+    {
+        ConfigureScripts(("lint", "eslint ."));
+        string[] arguments = targetingValue is null
+            ? ["run", "lint", targetingOption, "--", "--fix"]
+            : ["run", "lint", targetingOption, targetingValue, "--", "--fix"];
+
+        var resolved = _resolver.TryResolve(Invocation(
+            "npm",
+            arguments,
+            $"npm {string.Join(' ', arguments)}"));
+
+        Assert.Null(resolved);
+    }
+
+    [Theory]
+    [InlineData("--workspace", "web")]
+    [InlineData("--workspace=web", null)]
+    [InlineData("-w", "web")]
+    [InlineData("-w=web", null)]
+    [InlineData("--workspaces", null)]
+    [InlineData("--workspaces=web", null)]
+    [InlineData("--ws", null)]
+    [InlineData("--ws=web", null)]
+    [InlineData("-ws", null)]
+    [InlineData("-ws=web", null)]
+    [InlineData("--prefix", "/workspace/other")]
+    [InlineData("--prefix=/workspace/other", null)]
+    [InlineData("-C", "/workspace/other")]
+    [InlineData("-C=/workspace/other", null)]
+    public void TryResolve_NpmTargetingOptionAfterPassThroughSeparator_ResolvesScript(
+        string targetingOption,
+        string? targetingValue)
+    {
+        const string scriptCommand = "eslint .";
+        ConfigureScripts(("lint", scriptCommand));
+        string[] arguments = targetingValue is null
+            ? ["run", "lint", "--", targetingOption]
+            : ["run", "lint", "--", targetingOption, targetingValue];
+
+        var resolved = Resolve(
+            "npm",
+            arguments,
+            $"npm {string.Join(' ', arguments)}");
+
+        Assert.Equal(new ResolvedPackageScript("eslint", scriptCommand), resolved);
+    }
+
+    [Theory]
+    [InlineData("npm", "prelint")]
+    [InlineData("npm", "postlint")]
+    [InlineData("pnpm", "prelint")]
+    [InlineData("pnpm", "postlint")]
+    [InlineData("yarn", "prelint")]
+    [InlineData("yarn", "postlint")]
+    public void TryResolve_ScriptWithLifecycleHook_ReturnsNull(
+        string packageManager,
+        string hookName)
+    {
+        ConfigureScripts(
+            ("lint", "eslint ."),
+            (hookName, "node hook.js"));
+
+        var resolved = _resolver.TryResolve(Invocation(
+            packageManager,
+            ["run", "lint"],
+            $"{packageManager} run lint"));
+
+        Assert.Null(resolved);
+    }
+
+    [Theory]
+    [InlineData("bun")]
+    [InlineData("node")]
+    [InlineData("/opt/bin/corepack.cmd")]
+    [InlineData("/opt/bin/npm.sh")]
+    public void TryResolve_UnsupportedExecutable_ReturnsNullWithoutFileSystemCalls(
+        string executable)
+    {
+        var resolved = _resolver.TryResolve(Invocation(
+            executable,
+            ["run", "lint"],
+            $"{executable} run lint"));
+
+        Assert.Null(resolved);
+        Assert.Empty(_fileSystem.ReceivedCalls());
+    }
+
+    [Fact]
+    public void TryResolve_MissingPackageJson_ReturnsNullWithoutReadingFile()
+    {
+        var packageJsonPath = PackageJsonPath(WorkingDirectory);
+        _fileSystem.FileExists(packageJsonPath).Returns(false);
+
+        var resolved = _resolver.TryResolve(Invocation("pnpm", ["lint"], "pnpm lint"));
+
+        Assert.Null(resolved);
+        _fileSystem.DidNotReceive().ReadAllText(packageJsonPath);
+    }
+
+    [Fact]
+    public void TryResolve_UnreadablePackageJson_ReturnsNull()
+    {
+        var packageJsonPath = PackageJsonPath(WorkingDirectory);
+        _fileSystem.FileExists(packageJsonPath).Returns(true);
+        _fileSystem.ReadAllText(packageJsonPath).Returns(_ => throw new IOException("unreadable"));
+
+        var resolved = _resolver.TryResolve(Invocation("pnpm", ["lint"], "pnpm lint"));
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void TryResolve_InvalidJson_ReturnsNull()
+    {
+        ConfigurePackageJson("{ not valid json");
+
+        var resolved = _resolver.TryResolve(Invocation("pnpm", ["lint"], "pnpm lint"));
+
+        Assert.Null(resolved);
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("{\"scripts\":null}")]
+    [InlineData("{\"scripts\":[]}")]
+    public void TryResolve_AbsentOrInvalidScriptsObject_ReturnsNull(string packageJson)
+    {
+        ConfigurePackageJson(packageJson);
+
+        var resolved = _resolver.TryResolve(Invocation("yarn", ["lint"], "yarn lint"));
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void TryResolve_AbsentRequestedScript_ReturnsNull()
+    {
+        ConfigureScripts(("build", "tsc"));
+
+        var resolved = _resolver.TryResolve(Invocation("npm", ["run", "lint"], "npm run lint"));
+
+        Assert.Null(resolved);
+    }
+
+    [Theory]
+    [InlineData("{\"scripts\":{\"lint\":null}}")]
+    [InlineData("{\"scripts\":{\"lint\":42}}")]
+    [InlineData("{\"scripts\":{\"lint\":{}}}")]
+    [InlineData("{\"scripts\":{\"lint\":\"\"}}")]
+    [InlineData("{\"scripts\":{\"lint\":\"   \"}}")]
+    public void TryResolve_NonStringOrEmptyScript_ReturnsNull(string packageJson)
+    {
+        ConfigurePackageJson(packageJson);
+
+        var resolved = _resolver.TryResolve(Invocation("pnpm", ["lint"], "pnpm lint"));
+
+        Assert.Null(resolved);
+    }
+
+    private ResolvedPackageScript Resolve(
+        string executable,
+        IReadOnlyList<string> arguments,
+        string originalCommand,
+        string? workingDirectory = WorkingDirectory)
+    {
+        var resolved = _resolver.TryResolve(Invocation(executable, arguments, originalCommand, workingDirectory));
+        return Assert.IsType<ResolvedPackageScript>(resolved);
+    }
+
+    private static CommandInvocation Invocation(
+        string executable,
+        IReadOnlyList<string> arguments,
+        string originalCommand,
+        string? workingDirectory = WorkingDirectory) =>
+        new()
+        {
+            Executable = executable,
+            Arguments = arguments,
+            OriginalCommand = originalCommand,
+            WorkingDirectory = workingDirectory,
+        };
+
+    private void ConfigureScripts(params (string Name, string Command)[] scripts) =>
+        ConfigureScripts(WorkingDirectory, scripts);
+
+    private void ConfigureScripts(string workingDirectory, params (string Name, string Command)[] scripts)
+    {
+        var scriptMap = scripts.ToDictionary(script => script.Name, script => script.Command);
+        ConfigurePackageJson(JsonSerializer.Serialize(new { scripts = scriptMap }), workingDirectory);
+    }
+
+    private void ConfigurePackageJson(string json, string workingDirectory = WorkingDirectory)
+    {
+        var packageJsonPath = PackageJsonPath(workingDirectory);
+        _fileSystem.FileExists(packageJsonPath).Returns(true);
+        _fileSystem.ReadAllText(packageJsonPath).Returns(json);
+    }
+
+    private static string PackageJsonPath(string workingDirectory) =>
+        Path.Combine(workingDirectory, "package.json");
+}

--- a/tests/Hypa.UnitTests/Cli/RunCommandTests.cs
+++ b/tests/Hypa.UnitTests/Cli/RunCommandTests.cs
@@ -229,6 +229,7 @@ public sealed class RunCommandTests
         var filterRepo = Substitute.For<IFilterRepository>();
         var filterEngine = Substitute.For<IFilterEngine>();
         var parseMetrics = Substitute.For<IParseMetricsRepository>();
+        var packageScriptResolver = Substitute.For<IPackageManagerScriptResolver>();
 
         tokenCounter.EstimateTokens(Arg.Any<string>()).Returns(ci => ci.ArgAt<string>(0).Length);
         var session = new ContextSession { Id = Guid.NewGuid(), ProjectRoot = "/tmp" };
@@ -241,6 +242,8 @@ public sealed class RunCommandTests
             .Returns(ci => new FilterResult(ci.ArgAt<string>(1), "none", 0));
         parseMetrics.RecordAsync(Arg.Any<ParseMetricsRecord>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
+        packageScriptResolver.TryResolve(Arg.Any<CommandInvocation>())
+            .Returns((ResolvedPackageScript?)null);
 
         return new CommandRunnerService(
             runner,
@@ -250,6 +253,7 @@ public sealed class RunCommandTests
             evidence,
             resolver,
             configLoader,
+            packageScriptResolver,
             new FilterService(filterRepo, filterEngine),
             filterEngine,
             parseMetrics,

--- a/tests/Hypa.UnitTests/Infrastructure/Filters/BuiltInFiltersTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Filters/BuiltInFiltersTests.cs
@@ -145,6 +145,36 @@ public sealed class BuiltInFiltersTests
         Assert.Contains(pythonPipFilters, f => f.Id == "pip");
     }
 
+    [Theory]
+    [InlineData("eslint", "eslint .", "eslint")]
+    [InlineData("biome", "biome check .", "biome")]
+    [InlineData("oxlint", "oxlint .", "oxlint")]
+    [InlineData("jest", "jest", "jest")]
+    [InlineData("vitest", "vitest run", "jest")]
+    public void GetApplicableFilters_UsesResolvedPackageScriptPair(
+        string executable,
+        string command,
+        string expectedFilterId)
+    {
+        var service = MakeService(BuiltInFilters.All);
+
+        var filters = service.GetApplicableFilters(executable, command);
+
+        Assert.Contains(filters, filter => filter.Id == expectedFilterId);
+    }
+
+    [Fact]
+    public void GetApplicableFilters_ResolvedJestCommandMatchesWhereOriginalPnpmTestDoesNot()
+    {
+        var service = MakeService(BuiltInFilters.All);
+
+        var originalFilters = service.GetApplicableFilters("jest", "pnpm test");
+        var resolvedFilters = service.GetApplicableFilters("jest", "jest");
+
+        Assert.DoesNotContain(originalFilters, filter => filter.Id == "jest");
+        Assert.Contains(resolvedFilters, filter => filter.Id == "jest");
+    }
+
     [Fact]
     public void GetApplicableFilters_RecognisesBunRunnerPrefixes()
     {

--- a/tests/Hypa.UnitTests/Infrastructure/Reducers/PackageManagerOutputCompressorTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Reducers/PackageManagerOutputCompressorTests.cs
@@ -15,17 +15,66 @@ public sealed class PackageManagerOutputCompressorTests
     private static CommandOutput Out(string stdout, int exitCode = 0) =>
         CommandOutput.Captured(stdout, string.Empty, exitCode, TimeSpan.Zero);
 
-    [Fact]
-    public void CanHandle_Pnpm_ReturnsTrue() =>
-        Assert.True(Make().CanHandle(PkgInvocation("pnpm", "install")));
+    [Theory]
+    [InlineData("npm")]
+    [InlineData("pnpm")]
+    [InlineData("yarn")]
+    [InlineData("/usr/local/bin/npm")]
+    [InlineData("/usr/local/bin/pnpm")]
+    [InlineData("/usr/local/bin/yarn")]
+    [InlineData(@"C:\Program Files\nodejs\npm")]
+    [InlineData(@"C:\Program Files\nodejs\pnpm")]
+    [InlineData(@"C:\Program Files\nodejs\yarn")]
+    [InlineData("npm.cmd")]
+    [InlineData("pnpm.cmd")]
+    [InlineData("yarn.cmd")]
+    [InlineData("npm.bat")]
+    [InlineData("pnpm.bat")]
+    [InlineData("yarn.bat")]
+    [InlineData("npm.exe")]
+    [InlineData("pnpm.exe")]
+    [InlineData("yarn.exe")]
+    [InlineData("NpM")]
+    [InlineData("PnPm")]
+    [InlineData("YaRn")]
+    [InlineData("/usr/local/bin/NpM.CmD")]
+    [InlineData(@"C:\Program Files\nodejs\PnPm.ExE")]
+    [InlineData("/opt/bin/YaRn.CMD")]
+    [InlineData("/usr/local/bin/NpM.BaT")]
+    [InlineData(@"C:\Program Files\nodejs\PnPm.BaT")]
+    [InlineData("/opt/bin/YaRn.BAT")]
+    public void CanHandle_PackageManagerExecutable_ReturnsTrue(string executable) =>
+        Assert.True(Make().CanHandle(PkgInvocation(executable, "install")));
+
+    [Theory]
+    [InlineData("/usr/local/share/npm/node")]
+    [InlineData("/opt/pnpm/runner")]
+    [InlineData(@"C:\tools\yarn\custom.exe")]
+    public void CanHandle_UnrelatedPath_ReturnsFalse(string executable) =>
+        Assert.False(Make().CanHandle(PkgInvocation(executable, "install")));
+
+    [Theory]
+    [InlineData("npm.sh")]
+    [InlineData("pnpm.backup")]
+    [InlineData("yarn.local")]
+    [InlineData("/usr/local/bin/npm.sh")]
+    [InlineData(@"C:\Program Files\nodejs\pnpm.backup")]
+    [InlineData("/opt/bin/yarn.local")]
+    [InlineData("/usr/local/bin/NpM.Sh")]
+    [InlineData(@"C:\Program Files\nodejs\PnPm.BaCkUp")]
+    [InlineData("/opt/bin/YaRn.LoCaL")]
+    public void CanHandle_ArbitraryExecutableSuffix_ReturnsFalse(string executable) =>
+        Assert.False(Make().CanHandle(PkgInvocation(executable, "install")));
 
     [Fact]
-    public void CanHandle_Npm_ReturnsTrue() =>
-        Assert.True(Make().CanHandle(PkgInvocation("npm", "install")));
+    public void CanHandle_CustomPackageScripts_UsesRawPackageManagerExecutable()
+    {
+        var compressor = Make();
 
-    [Fact]
-    public void CanHandle_Yarn_ReturnsTrue() =>
-        Assert.True(Make().CanHandle(PkgInvocation("yarn")));
+        Assert.True(compressor.CanHandle(PkgInvocation("pnpm", "lint")));
+        Assert.True(compressor.CanHandle(PkgInvocation("npm", "run", "lint")));
+        Assert.True(compressor.CanHandle(PkgInvocation("yarn", "format")));
+    }
 
     [Fact]
     public void CanHandle_Git_ReturnsFalse() =>
@@ -45,6 +94,30 @@ public sealed class PackageManagerOutputCompressorTests
         var input = "added 10 packages\n";
         var result = Make().Compress(PkgInvocation("pnpm", "install"), Out(input, 0), CompressionOptions.Default);
         Assert.Equal("passthrough", result.ReducerId);
+    }
+
+    [Theory]
+    [InlineData("", "", 0, "", "passthrough")]
+    [InlineData("stdout only", "", 0, "stdout only", "passthrough")]
+    [InlineData("", "stderr only", 0, "stderr only", "passthrough")]
+    [InlineData("stdout", "stderr", 0, "stdout\nstderr", "passthrough")]
+    [InlineData("", "npm ERR! install failed", 1, "npm ERR! install failed", "pkg-manager")]
+    public void Compress_CombinesStreamsWithoutSyntheticBlankLines(
+        string stdout,
+        string stderr,
+        int exitCode,
+        string expectedText,
+        string expectedReducerId)
+    {
+        var output = CommandOutput.Captured(stdout, stderr, exitCode, TimeSpan.Zero);
+
+        var result = Make().Compress(
+            PkgInvocation("npm", "install"),
+            output,
+            CompressionOptions.Default);
+
+        Assert.Equal(expectedText, result.Text);
+        Assert.Equal(expectedReducerId, result.ReducerId);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- resolve npm, pnpm, and Yarn package scripts to their underlying tools for DSL filter matching
- apply tool-specific filters to unreduced package-script output while retaining package-manager compression as fallback
- preserve execution, metrics, diagnostics, platform semantics, and package-manager built-in behavior
- normalize package-manager executable paths and Windows shim suffixes

## Testing
- `dotnet test tests/Hypa.UnitTests/Hypa.UnitTests.csproj --filter "FullyQualifiedName~PackageManagerScriptResolverTests|FullyQualifiedName~CommandRunnerServiceTests|FullyQualifiedName~BuiltInFiltersTests|FullyQualifiedName~PackageManagerOutputCompressorTests|FullyQualifiedName~RunCommandTests" --no-restore` (284 passed)
- `dotnet build src/Hypa.Cli/Hypa.Cli.csproj -c Release /p:TreatWarningsAsErrors=true`
- `dotnet format --verify-no-changes`

Fixes #67