### PR TITLE
Fix tilde expansion across hypa -c, hypa_shell, and pi tools

### DIFF
--- a/packages/pi-hypa/extensions/tools.ts
+++ b/packages/pi-hypa/extensions/tools.ts
@@ -1,5 +1,5 @@
 import { mkdtemp, writeFile } from "node:fs/promises";
-import { platform, tmpdir } from "node:os";
+import { homedir, platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import { Text } from "@earendil-works/pi-tui";
 import type { HypaPiConfig } from "./types.js";
@@ -164,7 +164,16 @@ export function shellQuote(value: string, platformName: NodeJS.Platform = platfo
 }
 
 function normalizePathArg(path: string): string {
-  return path.startsWith("@") ? path.slice(1) : path;
+  // A leading "@" is an artifact of pi's file-mention syntax; strip it first.
+  const unprefixed = path.startsWith("@") ? path.slice(1) : path;
+  // Expand a leading "~" to the home directory, mirroring pi's native file
+  // tools, so the path reaches the Hypa CLI already absolute. Without this the
+  // tilde is passed through literally and then single-quoted by shellQuote, so
+  // neither the CLI nor a shell ever expands it. "~user/..." is intentionally
+  // left untouched (it needs the OS user database).
+  if (unprefixed === "~") return homedir();
+  if (unprefixed.startsWith("~/")) return homedir() + unprefixed.slice(1);
+  return unprefixed;
 }
 
 export function buildReadCommand(path: string, offset?: number, limit?: number): string {

--- a/packages/pi-hypa/test/tools.test.ts
+++ b/packages/pi-hypa/test/tools.test.ts
@@ -1,4 +1,5 @@
 import test from "node:test";
+import { homedir } from "node:os";
 import assert from "node:assert/strict";
 import { buildFindCommand, buildGrepCommand, buildLsCommand, buildReadCommand, limitStdoutLines, shellQuote } from "../extensions/tools.js";
 
@@ -80,6 +81,33 @@ test("limitStdoutLines floors and clamps limit to at least 1", () => {
   assert.equal(limitStdoutLines("a\nb\nc\n", 2.9), "a\nb\n");
   assert.equal(limitStdoutLines("a\nb\n", 0), "a\n");
   assert.equal(limitStdoutLines("a\nb\n", -3), "a\n");
+});
+
+test("normalizePathArg expands a leading ~ to the home directory", () => {
+  const home = homedir();
+  assert.equal(buildReadCommand("~/notes.txt"), `cat -- ${shellQuote(`${home}/notes.txt`)}`);
+  assert.equal(buildReadCommand("~"), `cat -- ${shellQuote(home)}`);
+  assert.equal(buildLsCommand({ path: "~" }), `ls -l -- ${shellQuote(home)}`);
+  assert.equal(
+    buildGrepCommand({ pattern: "needle", path: "~/src" }),
+    `rg --heading --line-number --color=never -e needle -- ${shellQuote(`${home}/src`)}`,
+  );
+  assert.equal(
+    buildFindCommand({ pattern: "*.ts", path: "~/src" }),
+    `rg --files --glob '*.ts' ${shellQuote(`${home}/src`)}`,
+  );
+});
+
+test("normalizePathArg strips a leading @ before expanding ~ (pi file-mention syntax)", () => {
+  const home = homedir();
+  assert.equal(buildReadCommand("@~/notes.txt"), `cat -- ${shellQuote(`${home}/notes.txt`)}`);
+  assert.equal(buildReadCommand("@/etc/hosts"), "cat -- /etc/hosts");
+});
+
+test("normalizePathArg leaves ~user, absolute, and relative paths untouched", () => {
+  assert.equal(buildReadCommand("~otheruser/file"), "cat -- '~otheruser/file'");
+  assert.equal(buildReadCommand("/etc/hosts"), "cat -- /etc/hosts");
+  assert.equal(buildReadCommand("./rel"), "cat -- ./rel");
 });
 
 test("buildLsCommand defaults to long listing", () => {

--- a/src/Hypa.Cli/Commands/RunCommand.cs
+++ b/src/Hypa.Cli/Commands/RunCommand.cs
@@ -86,6 +86,7 @@ public sealed class RunCommand(CommandRunnerService runnerService, IShellLexer s
         var usesShellSyntax =
             lexed.Any(t => t.Kind is TokenKind.Operator or TokenKind.Pipe or TokenKind.Redirect or TokenKind.Shellism)
             || ShellExpansion.ContainsExpansion(lexed)
+            || ShellExpansion.ContainsTildeExpansion(lexed)
             || ShellVerb.HasAssignmentPrefix(lexed)
             || (verb is not null && ShellBuiltins.IsStateful(verb));
 

--- a/src/Hypa.Infrastructure/Mcp/Tools/HypaShellTool.cs
+++ b/src/Hypa.Infrastructure/Mcp/Tools/HypaShellTool.cs
@@ -85,7 +85,10 @@ public sealed class HypaShellTool
                 : command;
 
             var lexed = shellLexer.Lex(effectiveCommand);
-            var usesShellSyntax = lexed.Any(t => t.Kind is TokenKind.Operator or TokenKind.Pipe or TokenKind.Redirect or TokenKind.Shellism);
+            var usesShellSyntax =
+                lexed.Any(t => t.Kind is TokenKind.Operator or TokenKind.Pipe or TokenKind.Redirect or TokenKind.Shellism)
+                || ShellExpansion.ContainsExpansion(lexed)
+                || ShellExpansion.ContainsTildeExpansion(lexed);
 
             var timeout = TimeSpan.FromMilliseconds(timeoutMs ?? 120_000);
             CommandInvocation invocation;

--- a/src/Hypa.Runtime/Domain/Rewrite/ShellExpansion.cs
+++ b/src/Hypa.Runtime/Domain/Rewrite/ShellExpansion.cs
@@ -1,6 +1,6 @@
 namespace Hypa.Runtime.Domain.Rewrite;
 
-/// Detects command-substitution and variable-expansion markers (`$`, `` ` ``)
+/// Detects command-substitution, variable-expansion, and tilde-expansion markers
 /// embedded inside argument tokens. Such tokens must be routed through
 /// `sh -c` so the shell performs the expansion; running the program directly
 /// would pass the unexpanded text through as a literal argument.
@@ -10,4 +10,57 @@ public static class ShellExpansion
         tokens.Any(token =>
             token.Kind is TokenKind.Arg or TokenKind.QuotedArg &&
             (token.Value.Contains('$') || token.Value.Contains('`')));
+
+    /// <summary>
+    /// Detects unquoted argument tokens that are POSIX tilde words:
+    /// <c>~</c>, <c>~/…</c>, <c>~user</c>, or <c>~user/…</c>. Tilde expansion
+    /// is performed by the shell only at the start of an unquoted word; running
+    /// the program directly would pass the literal text through as an argument,
+    /// so such commands must route through <c>sh -c</c>.
+    /// <para>
+    /// Quoted tildes (<c>"~/x"</c>), non-leading tildes (<c>a~b</c>), and
+    /// non-POSIX forms such as <c>~*</c> / <c>~?</c> are intentionally left on
+    /// the direct-execution path: the shell would not perform tilde expansion
+    /// for them, and routing would only change globbing semantics.
+    /// </para>
+    /// </summary>
+    public static bool ContainsTildeExpansion(IReadOnlyList<ShellToken> tokens) =>
+        tokens.Any(token =>
+            token.Kind is TokenKind.Arg &&
+            IsTildeWord(token.Value));
+
+    /// <summary>
+    /// Returns true for words a POSIX shell would treat as candidates for tilde
+    /// expansion: bare <c>~</c>, <c>~/path</c>, or <c>~login</c>/<c>~login/path</c>
+    /// where <c>login</c> is a non-empty sequence of portable username characters
+    /// (<c>A–Z a–z 0–9 _ . -</c>).
+    /// </summary>
+    private static bool IsTildeWord(string value)
+    {
+        if (value.Length == 0 || value[0] != '~')
+            return false;
+
+        if (value.Length == 1)
+            return true;
+
+        if (value[1] == '/')
+            return true;
+
+        // ~user or ~user/... — login name must be non-empty and free of
+        // metacharacters such as * ? [ that would otherwise force shell routing
+        // solely for globbing side effects.
+        var slash = value.IndexOf('/', 1);
+        var loginLength = slash < 0 ? value.Length - 1 : slash - 1;
+        if (loginLength <= 0)
+            return false;
+
+        for (var i = 1; i <= loginLength; i++)
+        {
+            var c = value[i];
+            if (!(char.IsAsciiLetterOrDigit(c) || c is '_' or '.' or '-'))
+                return false;
+        }
+
+        return true;
+    }
 }

--- a/tests/Hypa.UnitTests/Cli/RunCommandTests.cs
+++ b/tests/Hypa.UnitTests/Cli/RunCommandTests.cs
@@ -183,6 +183,118 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public async Task BufferedTildeArg_UsesShellInvocation()
+    {
+        var command = "echo ~/Desktop";
+        var (root, runner) = BuildRoot();
+        CommandInvocation? invocation = null;
+        runner.RunAsync(Arg.Do<CommandInvocation>(i => invocation = i), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("ok", "", 0, TimeSpan.Zero)));
+
+        var exitCode = await root.InvokeAsync(["-c", command]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(invocation);
+        Assert.Equal(ExpectedShell, invocation.Executable);
+        Assert.Equal(ExpectedShellArgs(command), invocation.Arguments);
+    }
+
+    [Fact]
+    public async Task BufferedBareTilde_UsesShellInvocation()
+    {
+        var command = "echo ~";
+        var (root, runner) = BuildRoot();
+        CommandInvocation? invocation = null;
+        runner.RunAsync(Arg.Do<CommandInvocation>(i => invocation = i), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("ok", "", 0, TimeSpan.Zero)));
+
+        var exitCode = await root.InvokeAsync(["-c", command]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(invocation);
+        Assert.Equal(ExpectedShell, invocation.Executable);
+        Assert.Equal(ExpectedShellArgs(command), invocation.Arguments);
+    }
+
+    [Fact]
+    public async Task BufferedTildeUser_UsesShellInvocation()
+    {
+        var command = "echo ~user/bin";
+        var (root, runner) = BuildRoot();
+        CommandInvocation? invocation = null;
+        runner.RunAsync(Arg.Do<CommandInvocation>(i => invocation = i), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("ok", "", 0, TimeSpan.Zero)));
+
+        var exitCode = await root.InvokeAsync(["-c", command]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(invocation);
+        Assert.Equal(ExpectedShell, invocation.Executable);
+        Assert.Equal(ExpectedShellArgs(command), invocation.Arguments);
+    }
+
+    [Fact]
+    public async Task BufferedDoubleQuotedTilde_UsesDirectInvocation()
+    {
+        // A tilde inside double quotes is not expanded by POSIX shells, so the
+        // direct-execution path is correct and must be preserved.
+        var command = "echo \"~/Desktop\"";
+        var (root, runner) = BuildRoot();
+        CommandInvocation? invocation = null;
+        runner.RunAsync(Arg.Do<CommandInvocation>(i => invocation = i), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("ok", "", 0, TimeSpan.Zero)));
+
+        var exitCode = await root.InvokeAsync(["-c", command]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(invocation);
+        Assert.NotEqual(ExpectedShell, invocation.Executable);
+    }
+
+    [Fact]
+    public async Task BufferedTildeNotAtStart_UsesDirectInvocation()
+    {
+        // A tilde that is not at the start of an unquoted word is not expanded,
+        // so the direct-execution path is correct and must be preserved.
+        var command = "echo a~b";
+        var (root, runner) = BuildRoot();
+        CommandInvocation? invocation = null;
+        runner.RunAsync(Arg.Do<CommandInvocation>(i => invocation = i), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("ok", "", 0, TimeSpan.Zero)));
+
+        var exitCode = await root.InvokeAsync(["-c", command]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(invocation);
+        Assert.NotEqual(ExpectedShell, invocation.Executable);
+    }
+
+    [Fact]
+    public async Task BufferedTildeGlobPattern_UsesDirectInvocation()
+    {
+        // ~* / ~? are not POSIX tilde words; routing them through the shell
+        // would only enable globbing side effects without performing tilde
+        // expansion. Keep the direct-execution path.
+        var command = "echo ~*";
+        var (root, runner) = BuildRoot();
+        CommandInvocation? invocation = null;
+        runner.RunAsync(Arg.Do<CommandInvocation>(i => invocation = i), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("ok", "", 0, TimeSpan.Zero)));
+
+        var exitCode = await root.InvokeAsync(["-c", command]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(invocation);
+        Assert.NotEqual(ExpectedShell, invocation.Executable);
+    }
+
+    [Fact]
     public async Task BufferedPlainCommand_UsesDirectInvocation()
     {
         var (root, runner) = BuildRoot();

--- a/tests/Hypa.UnitTests/Domain/ShellExpansionTests.cs
+++ b/tests/Hypa.UnitTests/Domain/ShellExpansionTests.cs
@@ -56,4 +56,122 @@ public sealed class ShellExpansionTests
 
         Assert.False(result);
     }
+
+    [Fact]
+    public void ContainsTildeExpansion_UnquotedLeadingTilde_ReturnsTrue()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "~/Desktop", 0),
+        };
+
+        Assert.True(ShellExpansion.ContainsTildeExpansion(tokens));
+    }
+
+    [Fact]
+    public void ContainsTildeExpansion_BareTilde_ReturnsTrue()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "~", 0),
+        };
+
+        Assert.True(ShellExpansion.ContainsTildeExpansion(tokens));
+    }
+
+    [Fact]
+    public void ContainsTildeExpansion_TildeSlashOnly_ReturnsTrue()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "~/", 0),
+        };
+
+        Assert.True(ShellExpansion.ContainsTildeExpansion(tokens));
+    }
+
+    [Fact]
+    public void ContainsTildeExpansion_TildeUser_ReturnsTrue()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "~user/bin", 0),
+        };
+
+        Assert.True(ShellExpansion.ContainsTildeExpansion(tokens));
+    }
+
+    [Fact]
+    public void ContainsTildeExpansion_BareTildeUser_ReturnsTrue()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "~user", 0),
+        };
+
+        Assert.True(ShellExpansion.ContainsTildeExpansion(tokens));
+    }
+
+    [Fact]
+    public void ContainsTildeExpansion_TildeUserWithDotsAndDashes_ReturnsTrue()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "~j.doe-1/bin", 0),
+        };
+
+        Assert.True(ShellExpansion.ContainsTildeExpansion(tokens));
+    }
+
+    [Fact]
+    public void ContainsTildeExpansion_QuotedTilde_ReturnsFalse()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.QuotedArg, "\"~/Desktop\"", 0),
+        };
+
+        Assert.False(ShellExpansion.ContainsTildeExpansion(tokens));
+    }
+
+    [Fact]
+    public void ContainsTildeExpansion_TildeNotAtStart_ReturnsFalse()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "a~b", 0),
+        };
+
+        Assert.False(ShellExpansion.ContainsTildeExpansion(tokens));
+    }
+
+    [Fact]
+    public void ContainsTildeExpansion_PlainArg_ReturnsFalse()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "plain", 0),
+        };
+
+        Assert.False(ShellExpansion.ContainsTildeExpansion(tokens));
+    }
+
+    [Theory]
+    [InlineData("~*")]
+    [InlineData("~?")]
+    [InlineData("~[a]")]
+    [InlineData("~user*")]
+    [InlineData("~user?x")]
+    public void ContainsTildeExpansion_GlobLikeTildeForms_ReturnFalse(string value)
+    {
+        // Copilot review on #65: ~* / ~? start with ~ but are not POSIX tilde
+        // words. Routing them through the shell would enable globbing without
+        // performing tilde expansion.
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, value, 0),
+        };
+
+        Assert.False(ShellExpansion.ContainsTildeExpansion(tokens));
+    }
 }

--- a/tests/Hypa.UnitTests/Infrastructure/Mcp/HypaShellToolTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Mcp/HypaShellToolTests.cs
@@ -160,6 +160,74 @@ public sealed class HypaShellToolTests
     }
 
     [Theory]
+    [InlineData("echo ~/Desktop")]
+    [InlineData("echo ~")]
+    [InlineData("echo ~user/bin")]
+    [InlineData("echo \"$HOME\"")]
+    public async Task HypaShell_ExpansionCommand_UsesShellInterpreter(string command)
+    {
+        CommandInvocation? captured = null;
+        var compressedRunner = Substitute.For<ICommandRunnerService>();
+        compressedRunner
+            .RunBufferedAsync(Arg.Do<CommandInvocation>(inv => captured = inv), Arg.Any<CompressionOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Result<BufferedRunOutput, Error>.Ok(new BufferedRunOutput("output", 0)));
+
+        var tokenCounter = Substitute.For<ITokenCounter>();
+        tokenCounter.EstimateTokens(Arg.Any<string>()).Returns(5);
+
+        await HypaShellTool.ExecuteAsync(
+            compressedRunner,
+            Substitute.For<ICommandRunner>(),
+            PassthroughRegistry(),
+            new ShellLexer(),
+            tokenCounter,
+            NoOpLedger(),
+            NoSessionResolver(),
+            NullLogger<HypaShellTool>.Instance,
+            new McpRuntimeOptions(),
+            CancellationToken.None,
+            command);
+
+        Assert.NotNull(captured);
+        var expectedExe = OperatingSystem.IsWindows() ? "cmd.exe" : "sh";
+        Assert.Equal(expectedExe, captured.Executable);
+        Assert.Equal(command, captured.OriginalCommand);
+    }
+
+    [Theory]
+    [InlineData("echo \"~/Desktop\"")]
+    [InlineData("echo a~b")]
+    [InlineData("echo ~*")]
+    public async Task HypaShell_NonExpandingTilde_UsesDirectProcessInvocation(string command)
+    {
+        CommandInvocation? captured = null;
+        var compressedRunner = Substitute.For<ICommandRunnerService>();
+        compressedRunner
+            .RunBufferedAsync(Arg.Do<CommandInvocation>(inv => captured = inv), Arg.Any<CompressionOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Result<BufferedRunOutput, Error>.Ok(new BufferedRunOutput("output", 0)));
+
+        var tokenCounter = Substitute.For<ITokenCounter>();
+        tokenCounter.EstimateTokens(Arg.Any<string>()).Returns(5);
+
+        await HypaShellTool.ExecuteAsync(
+            compressedRunner,
+            Substitute.For<ICommandRunner>(),
+            PassthroughRegistry(),
+            new ShellLexer(),
+            tokenCounter,
+            NoOpLedger(),
+            NoSessionResolver(),
+            NullLogger<HypaShellTool>.Instance,
+            new McpRuntimeOptions(),
+            CancellationToken.None,
+            command);
+
+        Assert.NotNull(captured);
+        var expectedShell = OperatingSystem.IsWindows() ? "cmd.exe" : "sh";
+        Assert.NotEqual(expectedShell, captured.Executable);
+    }
+
+    [Theory]
     [InlineData("echo hello | wc -c")]
     [InlineData("ls > /dev/null")]
     public async Task HypaShell_RawMode_ShellSyntaxCommand_UsesShellInterpreter(string command)


### PR DESCRIPTION
## Summary

Holistic fix for unquoted `~` not expanding. Supersedes #65 and #69 (complementary halves of the same user-facing bug) and also closes the same gap in MCP `hypa_shell`, which neither PR covered.

| Surface | Failure | Fix |
| --- | --- | --- |
| `hypa -c 'echo ~/x'` | direct `Process.Start`, literal `~/x` | route POSIX tilde words through `sh -c` / `cmd.exe /c` |
| MCP `hypa_shell` | same, and also missed `$` / backtick routing | same expansion heuristics as `RunCommand` |
| `hypa_read` / `grep` / `find` / `ls` path=`~/…` | path single-quoted before shell ever sees it | expand `~` / `~/…` in `normalizePathArg` before `shellQuote` |

## Why not approve #65 and #69 separately

They are correct in isolation and do not conflict, but:

1. Both are stale vs `main` after #70 (package-manager script filters).
2. #65 is incomplete for MCP: `HypaShellTool` still only checked operators/pipes/redirects/shellisms — no `$`/backtick and no tilde.
3. Copilot's review on #65 asked to tighten detection so `~*` / `~?` do not force shell routing (globbing side effects without real tilde expansion). That feedback is applied here.
4. One PR, one changelog line, one mental model for "tilde works".

## C# changes (from #65, tightened)

`ShellExpansion.ContainsTildeExpansion` now matches only POSIX tilde words:

- `~`, `~/…`
- `~user`, `~user/…` where login is `[A-Za-z0-9_.-]+`

Not matched (stay on direct path):

- quoted `"~/x"`
- non-leading `a~b`
- glob-like `~*`, `~?`, `~[a]`, `~user*`

Wired into:

- `RunCommand.HandleBufferedAsync` (`usesShellSyntax`)
- `HypaShellTool` (also adds the missing `ContainsExpansion` check for `$` / backticks so MCP parity matches CLI)

## pi-hypa changes (from #69)

```ts
function normalizePathArg(path: string): string {
  const unprefixed = path.startsWith("@") ? path.slice(1) : path;
  if (unprefixed === "~") return homedir();
  if (unprefixed.startsWith("~/")) return homedir() + unprefixed.slice(1);
  return unprefixed;
}
```

`~user/…` intentionally left alone (needs the OS user DB). `@~/…` strips `@` then expands.

## Verification

- `dotnet test` filter on ShellExpansion / RunCommand tilde / HypaShell expansion: **33 passed**
- `npm test --prefix packages/pi-hypa`: **70/70**
- E2E against built CLI:

| Command | Result |
| --- | --- |
| `echo ~` | `/Users/…` |
| `echo ~/Desktop` | `/Users/…/Desktop` |
| `echo "~/Desktop"` | `~/Desktop` (quoted, correct) |
| `echo a~b` | `a~b` |
| `echo ~*` | `~*` (no forced shell routing) |

## Closes

Supersedes #65, #69. Related: #42, #44, #46.