### PR TITLE
Fix subshell rewrite corruption and CRLF output loss

### DIFF
--- a/src/Hypa.Infrastructure/Compression/Stages/ProgressFilterStage.cs
+++ b/src/Hypa.Infrastructure/Compression/Stages/ProgressFilterStage.cs
@@ -19,9 +19,19 @@ public sealed partial class ProgressFilterStage : ICompressionStage
         var filtered = new List<string>(lines.Length);
         foreach (var line in lines)
         {
-            // Lines that end with \r are progress-bar overwrites.
+            // Lines that end with \r are progress-bar overwrites only if the
+            // content underneath (with trailing \r stripped) looks like one;
+            // otherwise this is ordinary CRLF-terminated text and must be kept
+            // verbatim, trailing \r included.
             if (line.EndsWith('\r'))
+            {
+                var content = line.TrimEnd('\r');
+                if (IsProgressBarLine(content) ||
+                    (SpinnerOnly().IsMatch(content) && content.Trim().Length > 0))
+                    continue;
+                filtered.Add(line);
                 continue;
+            }
             if (IsProgressBarLine(line))
                 continue;
             if (SpinnerOnly().IsMatch(line) && line.Trim().Length > 0)

--- a/src/Hypa.Infrastructure/Rewrite/ShellLexer.cs
+++ b/src/Hypa.Infrastructure/Rewrite/ShellLexer.cs
@@ -28,7 +28,7 @@ public sealed class ShellLexer : IShellLexer
             }
 
             // Unknown shell constructs — return single Shellism to signal passthrough
-            if (ch == '$' || ch == '`')
+            if (ch == '$' || ch == '`' || ch == '(' || ch == ')')
                 return [new ShellToken(TokenKind.Shellism, command, 0)];
 
             // Quoted arg
@@ -103,7 +103,7 @@ public sealed class ShellLexer : IShellLexer
     {
         var ch = s[i];
         if (char.IsWhiteSpace(ch)) return true;
-        if (ch is '\'' or '"' or '$' or '`' or '|' or '&' or ';') return true;
+        if (ch is '\'' or '"' or '$' or '`' or '|' or '&' or ';' or '(' or ')') return true;
         if (ch == '>' || ch == '<') return true;
         return false;
     }

--- a/tests/Hypa.UnitTests/Infrastructure/CommandRewriteRegistryTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/CommandRewriteRegistryTests.cs
@@ -264,6 +264,26 @@ public sealed class CommandRewriteRegistryTests
         Assert.Equal(RewriteOutcome.Passthrough, result.Outcome);
     }
 
+    [Fact]
+    public void SubshellGroup_ReturnsPassthrough()
+    {
+        var registry = BuildRegistry();
+        const string input = "ls /tmp/nonexistent 2>/dev/null && echo \"HAS SRC\" || (echo \"Cloning via git...\" && mkdir -p /tmp/y && git clone --depth 1 https://example.com/r.git /tmp/y/r 2>&1 | tail -5)";
+        var result = registry.Rewrite(input, DefaultContext);
+        Assert.Equal(RewriteOutcome.Passthrough, result.Outcome);
+        Assert.Null(result.Command);
+    }
+
+    [Fact]
+    public void CompoundCommand_WithSubshellGroup_ReturnsPassthrough()
+    {
+        var registry = BuildRegistry();
+        const string input = "echo a && (echo b)";
+        var result = registry.Rewrite(input, DefaultContext);
+        Assert.Equal(RewriteOutcome.Passthrough, result.Outcome);
+        Assert.Null(result.Command);
+    }
+
     // --- Compound rewriting ---
 
     [Theory]

--- a/tests/Hypa.UnitTests/Infrastructure/Compression/GenericOutputCompressorTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Compression/GenericOutputCompressorTests.cs
@@ -56,6 +56,17 @@ public sealed class GenericOutputCompressorTests
     }
 
     [Fact]
+    public void Compress_CrlfOutput_ContentSurvives()
+    {
+        var compressor = MakeCompressor();
+        var input = "Cloning repository.\r\nResolving dependencies.\r\nBuild succeeded.";
+        var result = compressor.Compress(FakeInvocation(), FakeOutput(input), CompressionOptions.Default);
+        Assert.Contains("Cloning repository.", result.Text);
+        Assert.Contains("Resolving dependencies.", result.Text);
+        Assert.Contains("Build succeeded.", result.Text);
+    }
+
+    [Fact]
     public void CanHandle_AlwaysTrue()
     {
         var compressor = MakeCompressor();

--- a/tests/Hypa.UnitTests/Infrastructure/Compression/ProgressFilterStageTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Compression/ProgressFilterStageTests.cs
@@ -8,13 +8,44 @@ public sealed class ProgressFilterStageTests
     private readonly ProgressFilterStage _stage = new();
 
     [Fact]
-    public void Apply_CarriageReturnLine_Removed()
+    public void Apply_CarriageReturnProgressBarLine_Removed()
     {
-        // Terminal progress line: ends with \r before the newline separator
-        var input = "progress\r\nline2";
+        // Terminal progress-bar overwrite: ends with \r before the newline separator.
+        var input = "[##########] 50%\r\nline2";
         var result = _stage.Apply(input);
-        Assert.DoesNotContain("progress", result);
+        Assert.DoesNotContain("[##########]", result);
         Assert.Contains("line2", result);
+    }
+
+    [Fact]
+    public void Apply_CarriageReturnSpinnerLine_Removed()
+    {
+        var input = "before\n⠋⠙⠹\r\nafter";
+        var result = _stage.Apply(input);
+        Assert.DoesNotContain("⠋⠙⠹", result);
+        Assert.Contains("before", result);
+        Assert.Contains("after", result);
+    }
+
+    [Fact]
+    public void Apply_CrlfProseLines_AllPreserved()
+    {
+        var input = "First line of output.\r\nSecond line of output.\r\nThird line of output.";
+        var result = _stage.Apply(input);
+        Assert.Contains("First line of output.", result);
+        Assert.Contains("Second line of output.", result);
+        Assert.Contains("Third line of output.", result);
+    }
+
+    [Fact]
+    public void Apply_CrlfMixedWithProgressBar_ProseKeptProgressDropped()
+    {
+        var input = "Starting build.\r\nCompiling module foo.\r\n[####] 100%\r\nBuild complete.";
+        var result = _stage.Apply(input);
+        Assert.Contains("Starting build.", result);
+        Assert.Contains("Compiling module foo.", result);
+        Assert.Contains("Build complete.", result);
+        Assert.DoesNotContain("[####] 100%", result);
     }
 
     [Fact]

--- a/tests/Hypa.UnitTests/Infrastructure/ShellLexerTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/ShellLexerTests.cs
@@ -91,6 +91,39 @@ public sealed class ShellLexerTests
     }
 
     [Fact]
+    public void SubshellGroup_ReturnsSingleShellism()
+    {
+        var tokens = _lexer.Lex("(echo a && echo b)");
+        Assert.Single(tokens);
+        Assert.Equal(TokenKind.Shellism, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void CompoundCommandWithSubshellGroup_ReturnsSingleShellism()
+    {
+        var tokens = _lexer.Lex("ls x && echo y || (echo z && mkdir -p /tmp/y)");
+        Assert.Single(tokens);
+        Assert.Equal(TokenKind.Shellism, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void MidArgParen_ReturnsSingleShellism()
+    {
+        var tokens = _lexer.Lex("echo foo(bar)");
+        Assert.Single(tokens);
+        Assert.Equal(TokenKind.Shellism, tokens[0].Kind);
+    }
+
+    [Fact]
+    public void QuotedParens_DoNotTriggerShellism()
+    {
+        var tokens = _lexer.Lex("echo \"(quoted)\" && echo b");
+        Assert.DoesNotContain(tokens, t => t.Kind == TokenKind.Shellism);
+        Assert.Contains(tokens, t => t.Kind == TokenKind.QuotedArg && t.Value == "\"(quoted)\"");
+        Assert.Contains(tokens, t => t.Kind == TokenKind.Operator && t.Value == "&&");
+    }
+
+    [Fact]
     public void TokensPreserveOffsets()
     {
         var tokens = _lexer.Lex("git status");


### PR DESCRIPTION
Fixes #66
Fixes #68

## Rewrite: subshell groups produced invalid shell (#66)

`ShellLexer` did not tokenise `(` / `)`, so `CommandRewriteRegistry` split compound commands straight across subshell boundaries — the `(` landed inside one `hypa -c "..."` argument while its `)` was stranded outside, producing `syntax error near unexpected token ')'`.

Fix: top-level unquoted `(` / `)` now lex as `TokenKind.Shellism` (same handling as `$` and backticks), and `IsSpecialStart` includes both so a mid-arg paren terminates the current arg token and triggers the same path. The registry already passes through on any Shellism token, so subshell-containing commands are left untouched. Parens inside quotes are consumed by the quoted-arg branch and do not trigger passthrough. Trade-off per the issue: subshell contents are no longer compressed — correctness > compression.

```
$ hypa rewrite --json 'ls /tmp/nonexistent 2>/dev/null && echo "HAS SRC" || (echo "Cloning..." && mkdir -p /tmp/y)'
{"outcome":"Passthrough", ...command unchanged...}
$ hypa rewrite --json 'echo a && echo b'
{"outcome":"Rewritten","command":"hypa -c \"echo a\" && hypa -c \"echo b\""}   # unchanged behavior
```

## Compression: ProgressFilterStage erased all CRLF content (#68)

`ProgressFilterStage.Apply` split on `\n` and unconditionally dropped every line ending in `\r` as a "progress-bar overwrite" — which is every line of CRLF-terminated text, silently compressing entire files/outputs to nothing (`→1 tok, -100%`).

Fix (option A from the issue): a `\r`-terminated line is filtered only when its content, with the trailing `\r` run stripped, also matches the progress-bar or spinner heuristics; otherwise it is kept verbatim. Genuine `[####] 50%\r` overwrites and spinner frames are still removed; LF-only behavior is byte-identical to before.

## Tests

- 4 new `ShellLexerTests` (subshell group, issue-repro compound, mid-arg paren, quoted parens not triggering) + 2 new `CommandRewriteRegistryTests` asserting `Passthrough` on the exact #66 repro.
- 4 new `ProgressFilterStageTests` (CRLF prose preserved, `\r` progress bar filtered, `\r` spinner filtered, mixed) + 1 end-to-end `GenericOutputCompressorTests` CRLF case; the old test asserting the unconditional `\r` drop was replaced.

## Verification

- Release build with `TreatWarningsAsErrors=true`: clean
- 1715 unit + 32 golden + 18 integration tests: pass
- `dotnet format --verify-no-changes`: clean
- Both issue repros smoke-tested via the CLI (before/after shown above)
