### PR TITLE
Fix hypa init crash on mixed-type packages[] in pi settings

### DIFF
--- a/src/Hypa.Infrastructure/Hooks/HookInstaller.cs
+++ b/src/Hypa.Infrastructure/Hooks/HookInstaller.cs
@@ -414,7 +414,9 @@ public sealed class HookInstaller : IHookInstaller
             {
                 foreach (var item in existingArray)
                 {
-                    if (item?.GetValue<string>() == op.Value)
+                    // Tolerate mixed arrays (string + object entries). Match string elements
+                    // or objects whose "source" equals the target — never throw on non-strings.
+                    if (JsonArrayValueHelper.ItemMatches(item, op.Value))
                         return new InstallEntry(description, InstallStatus.AlreadyPresent);
                 }
             }

--- a/src/Hypa.Infrastructure/Hooks/HookUninstaller.cs
+++ b/src/Hypa.Infrastructure/Hooks/HookUninstaller.cs
@@ -355,10 +355,12 @@ public sealed class HookUninstaller : IHookUninstaller
             if (root[op.TopLevelKey] is not JsonArray array)
                 return new UninstallEntry(description, UninstallStatus.NotPresent);
 
+            // Tolerate mixed arrays (string + object entries). Match string elements
+            // or objects whose "source" equals the target — never throw on non-strings.
             var index = -1;
             for (var i = 0; i < array.Count; i++)
             {
-                if (array[i]?.GetValue<string>() == op.Value)
+                if (JsonArrayValueHelper.ItemMatches(array[i], op.Value))
                 {
                     index = i;
                     break;

--- a/src/Hypa.Infrastructure/Hooks/JsonArrayValueHelper.cs
+++ b/src/Hypa.Infrastructure/Hooks/JsonArrayValueHelper.cs
@@ -1,0 +1,31 @@
+using System.Text.Json.Nodes;
+
+namespace Hypa.Infrastructure.Hooks;
+
+/// <summary>
+/// Membership identity for top-level JSON array value ops (e.g. Pi packages[]).
+/// Matches a scalar string element, or an object whose string "source" equals the target.
+/// Non-string siblings are never treated as errors — they simply do not match.
+/// </summary>
+internal static class JsonArrayValueHelper
+{
+    internal static bool ItemMatches(JsonNode? item, string value)
+    {
+        if (item is null)
+            return false;
+
+        if (item is JsonValue jsonValue &&
+            jsonValue.TryGetValue<string>(out var stringValue) &&
+            stringValue == value)
+            return true;
+
+        if (item is JsonObject obj &&
+            obj.TryGetPropertyValue("source", out var sourceNode) &&
+            sourceNode is JsonValue sourceValue &&
+            sourceValue.TryGetValue<string>(out var source) &&
+            source == value)
+            return true;
+
+        return false;
+    }
+}

--- a/src/Hypa.Runtime/Domain/Hooks/InstallOperation.cs
+++ b/src/Hypa.Runtime/Domain/Hooks/InstallOperation.cs
@@ -53,7 +53,12 @@ public abstract record InstallOperation
         string ObjectJson
     ) : InstallOperation;
 
-    /// <summary>Add a scalar string value to a top-level JSON array if absent.</summary>
+    /// <summary>
+    /// Add a scalar string value to a top-level JSON array if absent.
+    /// Already-present identity: string element equals <see cref="Value"/>, or object element
+    /// with string property <c>source</c> equal to <see cref="Value"/>. Non-matching non-string
+    /// siblings are preserved and do not cause errors. Always appends the scalar string form.
+    /// </summary>
     public sealed record PatchJsonArrayValue(
         string FilePath,
         string TopLevelKey,

--- a/src/Hypa.Runtime/Domain/Hooks/UninstallOperation.cs
+++ b/src/Hypa.Runtime/Domain/Hooks/UninstallOperation.cs
@@ -31,7 +31,12 @@ public abstract record UninstallOperation
         string ObjectKey
     ) : UninstallOperation;
 
-    /// <summary>Remove a scalar string value from a top-level JSON array.</summary>
+    /// <summary>
+    /// Remove a matching entry from a top-level JSON array.
+    /// Match identity: string element equals <see cref="Value"/>, or object element with string
+    /// property <c>source</c> equal to <see cref="Value"/>. Non-matching siblings (including
+    /// objects without a matching source) are preserved. Removes the key if the array becomes empty.
+    /// </summary>
     public sealed record RemoveJsonArrayValue(
         string FilePath,
         string TopLevelKey,

--- a/tests/Hypa.UnitTests/Infrastructure/Hooks/HookInstallerTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Hooks/HookInstallerTests.cs
@@ -690,6 +690,39 @@ public sealed class HookInstallerTests : IDisposable
         Assert.Equal(original, await File.ReadAllTextAsync(settingsPath));
     }
 
+    [Fact]
+    public async Task PatchJsonArrayValue_NonStringSiblings_DoesNotThrowAndAppends()
+    {
+        // Guard the helper's never-throw contract beyond Pi's usual string/object forms.
+        var settingsPath = Path.Combine(_tempDir, "settings.json");
+        await File.WriteAllTextAsync(settingsPath, """
+            {
+              "packages": [
+                null,
+                42,
+                true,
+                ["nested"],
+                { "source": 123 },
+                { "noSource": "x" },
+                "npm:other"
+              ]
+            }
+            """);
+        var plan = new InstallPlan([
+            new InstallOperation.PatchJsonArrayValue(settingsPath, "packages", "/repo/packages/pi-hypa")
+        ]);
+
+        var report = await _installer.InstallAsync(plan, "pi", dryRun: false);
+
+        Assert.Equal(InstallStatus.Installed, report.Entries[0].Status);
+        Assert.Null(report.Entries[0].Detail);
+        var content = await File.ReadAllTextAsync(settingsPath);
+        Assert.Contains("/repo/packages/pi-hypa", content);
+        Assert.Contains("npm:other", content);
+        Assert.Contains("nested", content);
+        Assert.Contains("noSource", content);
+    }
+
     // --- Report structure ---
 
     [Fact]

--- a/tests/Hypa.UnitTests/Infrastructure/Hooks/HookInstallerTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Hooks/HookInstallerTests.cs
@@ -613,6 +613,83 @@ public sealed class HookInstallerTests : IDisposable
         Assert.Equal(InstallStatus.AlreadyPresent, report.Entries[0].Status);
     }
 
+    [Fact]
+    public async Task PatchJsonArrayValue_MixedArray_AppendsStringAndPreservesObjects()
+    {
+        var settingsPath = Path.Combine(_tempDir, "settings.json");
+        await File.WriteAllTextAsync(settingsPath, """
+            {
+              "packages": [
+                "npm:other",
+                { "source": "git:example/pkg", "extensions": ["./ext.ts"] }
+              ],
+              "otherKey": true
+            }
+            """);
+        var plan = new InstallPlan([
+            new InstallOperation.PatchJsonArrayValue(settingsPath, "packages", "/repo/packages/pi-hypa")
+        ]);
+
+        var report = await _installer.InstallAsync(plan, "pi", dryRun: false);
+
+        Assert.Equal(InstallStatus.Installed, report.Entries[0].Status);
+        Assert.Null(report.Entries[0].Detail);
+        var content = await File.ReadAllTextAsync(settingsPath);
+        Assert.Contains("/repo/packages/pi-hypa", content);
+        Assert.Contains("npm:other", content);
+        Assert.Contains("git:example/pkg", content);
+        Assert.Contains("extensions", content);
+        Assert.Contains("otherKey", content);
+        Assert.DoesNotContain("JsonValue", report.Entries[0].Detail ?? "");
+    }
+
+    [Fact]
+    public async Task PatchJsonArrayValue_ObjectSourceAlreadyPresent_ReportsAlreadyPresent()
+    {
+        var settingsPath = Path.Combine(_tempDir, "settings.json");
+        await File.WriteAllTextAsync(settingsPath, """
+            {
+              "packages": [
+                "npm:other",
+                { "source": "/repo/packages/pi-hypa", "extensions": ["./hypa.ts"] }
+              ]
+            }
+            """);
+        var plan = new InstallPlan([
+            new InstallOperation.PatchJsonArrayValue(settingsPath, "packages", "/repo/packages/pi-hypa")
+        ]);
+
+        var report = await _installer.InstallAsync(plan, "pi", dryRun: false);
+
+        Assert.Equal(InstallStatus.AlreadyPresent, report.Entries[0].Status);
+        var content = await File.ReadAllTextAsync(settingsPath);
+        // Must not duplicate a string entry when object source already matches.
+        Assert.Equal(1, content.Split("/repo/packages/pi-hypa", StringSplitOptions.None).Length - 1);
+    }
+
+    [Fact]
+    public async Task PatchJsonArrayValue_MixedArray_DryRun_DoesNotWriteOrError()
+    {
+        var settingsPath = Path.Combine(_tempDir, "settings.json");
+        var original = """
+            {
+              "packages": [
+                { "source": "git:example/pkg" },
+                "npm:other"
+              ]
+            }
+            """;
+        await File.WriteAllTextAsync(settingsPath, original);
+        var plan = new InstallPlan([
+            new InstallOperation.PatchJsonArrayValue(settingsPath, "packages", "npm:@hypabolic/pi-hypa")
+        ]);
+
+        var report = await _installer.InstallAsync(plan, "pi", dryRun: true);
+
+        Assert.Equal(InstallStatus.Installed, report.Entries[0].Status);
+        Assert.Equal(original, await File.ReadAllTextAsync(settingsPath));
+    }
+
     // --- Report structure ---
 
     [Fact]

--- a/tests/Hypa.UnitTests/Infrastructure/Hooks/HookUninstallerTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Hooks/HookUninstallerTests.cs
@@ -642,6 +642,106 @@ public sealed class HookUninstallerTests : IDisposable
     }
 
     [Fact]
+    public async Task RemoveJsonArrayValue_MixedArray_RemovesMatchingStringAndPreservesObjects()
+    {
+        var path = Path.Combine(_tempDir, "settings.json");
+        await File.WriteAllTextAsync(path, """
+            {
+              "packages": [
+                "npm:other",
+                "/repo/packages/pi-hypa",
+                { "source": "git:example/pkg", "extensions": ["./ext.ts"] }
+              ]
+            }
+            """);
+        var plan = new UninstallPlan([
+            new UninstallOperation.RemoveJsonArrayValue(path, "packages", "/repo/packages/pi-hypa")
+        ]);
+
+        var report = await _uninstaller.UninstallAsync(plan, "pi", dryRun: false);
+
+        Assert.Equal(UninstallStatus.Removed, report.Entries[0].Status);
+        var content = await File.ReadAllTextAsync(path);
+        Assert.DoesNotContain("/repo/packages/pi-hypa", content);
+        Assert.Contains("npm:other", content);
+        Assert.Contains("git:example/pkg", content);
+        Assert.Contains("extensions", content);
+    }
+
+    [Fact]
+    public async Task RemoveJsonArrayValue_MixedArray_NoMatch_ReturnsNotPresent()
+    {
+        var path = Path.Combine(_tempDir, "settings.json");
+        await File.WriteAllTextAsync(path, """
+            {
+              "packages": [
+                "npm:other",
+                { "source": "git:example/pkg" }
+              ]
+            }
+            """);
+        var plan = new UninstallPlan([
+            new UninstallOperation.RemoveJsonArrayValue(path, "packages", "/repo/packages/pi-hypa")
+        ]);
+
+        var report = await _uninstaller.UninstallAsync(plan, "pi", dryRun: false);
+
+        Assert.Equal(UninstallStatus.NotPresent, report.Entries[0].Status);
+        var content = await File.ReadAllTextAsync(path);
+        Assert.Contains("npm:other", content);
+        Assert.Contains("git:example/pkg", content);
+    }
+
+    [Fact]
+    public async Task RemoveJsonArrayValue_ObjectSourceMatch_RemovesObjectEntry()
+    {
+        var path = Path.Combine(_tempDir, "settings.json");
+        await File.WriteAllTextAsync(path, """
+            {
+              "packages": [
+                "npm:other",
+                { "source": "/repo/packages/pi-hypa", "extensions": ["./hypa.ts"] }
+              ]
+            }
+            """);
+        var plan = new UninstallPlan([
+            new UninstallOperation.RemoveJsonArrayValue(path, "packages", "/repo/packages/pi-hypa")
+        ]);
+
+        var report = await _uninstaller.UninstallAsync(plan, "pi", dryRun: false);
+
+        Assert.Equal(UninstallStatus.Removed, report.Entries[0].Status);
+        var content = await File.ReadAllTextAsync(path);
+        Assert.DoesNotContain("/repo/packages/pi-hypa", content);
+        Assert.DoesNotContain("hypa.ts", content);
+        Assert.Contains("npm:other", content);
+    }
+
+    [Fact]
+    public async Task RemoveJsonArrayValue_ObjectSourceOnlyEntry_RemovesPackagesKey()
+    {
+        var path = Path.Combine(_tempDir, "settings.json");
+        await File.WriteAllTextAsync(path, """
+            {
+              "packages": [
+                { "source": "/repo/packages/pi-hypa" }
+              ],
+              "otherKey": 1
+            }
+            """);
+        var plan = new UninstallPlan([
+            new UninstallOperation.RemoveJsonArrayValue(path, "packages", "/repo/packages/pi-hypa")
+        ]);
+
+        var report = await _uninstaller.UninstallAsync(plan, "pi", dryRun: false);
+
+        Assert.Equal(UninstallStatus.Removed, report.Entries[0].Status);
+        var content = await File.ReadAllTextAsync(path);
+        Assert.DoesNotContain("packages", content);
+        Assert.Contains("otherKey", content);
+    }
+
+    [Fact]
     public async Task RemoveJsonHook_DryRun_DoesNotCreateBackup()
     {
         var path = Path.Combine(_tempDir, "settings.json");

--- a/tests/Hypa.UnitTests/Infrastructure/Hooks/HookUninstallerTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Hooks/HookUninstallerTests.cs
@@ -742,6 +742,37 @@ public sealed class HookUninstallerTests : IDisposable
     }
 
     [Fact]
+    public async Task RemoveJsonArrayValue_NonStringSiblings_RemovesMatchAndPreservesSiblings()
+    {
+        var path = Path.Combine(_tempDir, "settings.json");
+        await File.WriteAllTextAsync(path, """
+            {
+              "packages": [
+                null,
+                42,
+                true,
+                ["nested"],
+                { "source": 123 },
+                "/repo/packages/pi-hypa",
+                "npm:other"
+              ]
+            }
+            """);
+        var plan = new UninstallPlan([
+            new UninstallOperation.RemoveJsonArrayValue(path, "packages", "/repo/packages/pi-hypa")
+        ]);
+
+        var report = await _uninstaller.UninstallAsync(plan, "pi", dryRun: false);
+
+        Assert.Equal(UninstallStatus.Removed, report.Entries[0].Status);
+        var content = await File.ReadAllTextAsync(path);
+        Assert.DoesNotContain("/repo/packages/pi-hypa", content);
+        Assert.Contains("npm:other", content);
+        Assert.Contains("nested", content);
+        Assert.Contains("42", content);
+    }
+
+    [Fact]
     public async Task RemoveJsonHook_DryRun_DoesNotCreateBackup()
     {
         var path = Path.Combine(_tempDir, "settings.json");


### PR DESCRIPTION
## Summary

`hypa init --agent pi` crashed when Pi settings `packages[]` mixed string and object entries (e.g. `{ "source": "git:...", "extensions": [...] }`). Install and uninstall scanned every array element with `GetValue<string>()`, which throws on JSON objects (`The node must be of type 'JsonValue'.`).

This fix:

- Adds `JsonArrayValueHelper.ItemMatches` shared by install already-present checks and uninstall index lookup
- Matches a scalar string **or** an object whose string `source` equals the target (parity with `PiAdapter.SettingsContainsPackage`)
- Skips non-string siblings without throwing and preserves them when rewriting
- Continues to **add** only the scalar string form Hypa uses today
- Removes matching string or object-source entries on uninstall; drops the `packages` key if the array becomes empty

## Test plan

- [x] `dotnet test tests/Hypa.UnitTests --filter "FullyQualifiedName~PatchJsonArrayValue|FullyQualifiedName~RemoveJsonArrayValue"` (13 passed)
- [x] `dotnet test tests/Hypa.UnitTests --filter "FullyQualifiedName~Infrastructure.Hooks"` (248 passed, before extra sibling tests; focused suite green after)
- [x] Existing all-string install/uninstall array tests still pass
- [x] Mixed array: install appends string, preserves objects
- [x] Object `source` already present → AlreadyPresent (no duplicate)
- [x] Mixed array uninstall: string remove / object-source remove / NotPresent
- [x] Non-string siblings (null, number, bool, nested array) do not throw

## Codex review

- Model: `gpt-5.6-luna` with `model_reasoning_effort=xhigh`
- Verdict: **pass_after_fix** (0 open bugs; applied suggestion for non-string sibling coverage tests)

## Closes

Closes #82
