### PR TITLE
Fix Windows spawn failing on npm shims ahead of PATHEXT executables

### DIFF
--- a/src/Hypa.Infrastructure/Runner/ProcessCommandRunner.cs
+++ b/src/Hypa.Infrastructure/Runner/ProcessCommandRunner.cs
@@ -9,14 +9,22 @@ public sealed class ProcessCommandRunner : ICommandRunner
 {
     public async Task<Result<CommandOutput, Error>> RunAsync(CommandInvocation invocation, CancellationToken ct)
     {
+        // Resolve Windows bare names with PATHEXT and wrap .cmd/.bat via cmd.exe.
+        // Keep invocation.Executable unchanged for compressors/filters.
+        var plan = WindowsExecutableResolver.Resolve(
+            invocation.Executable,
+            invocation.Arguments,
+            invocation.WorkingDirectory,
+            invocation.EnvOverrides);
+
         var psi = new ProcessStartInfo
         {
-            FileName = invocation.Executable,
+            FileName = plan.FileName,
             UseShellExecute = false,
             CreateNoWindow = invocation.Mode == ToolRunMode.Buffered,
         };
 
-        foreach (var arg in invocation.Arguments)
+        foreach (var arg in plan.Arguments)
             psi.ArgumentList.Add(arg);
 
         if (invocation.WorkingDirectory is not null)

--- a/src/Hypa.Infrastructure/Runner/ProcessCommandRunner.cs
+++ b/src/Hypa.Infrastructure/Runner/ProcessCommandRunner.cs
@@ -24,8 +24,11 @@ public sealed class ProcessCommandRunner : ICommandRunner
             CreateNoWindow = invocation.Mode == ToolRunMode.Buffered,
         };
 
-        foreach (var arg in plan.Arguments)
-            psi.ArgumentList.Add(arg);
+        // cmd.exe /c payloads are already cmd-quoted (paths with spaces, etc.).
+        // ProcessStartInfo.ArgumentList re-escapes via PasteArguments and breaks those
+        // quotes (e.g. Node under "C:\Program Files\nodejs\npm.cmd"). Use the raw
+        // Arguments string for the wrap path; ArgumentList for normal direct spawns.
+        WindowsExecutableResolver.ApplySpawnPlan(psi, plan);
 
         if (invocation.WorkingDirectory is not null)
             psi.WorkingDirectory = invocation.WorkingDirectory;

--- a/src/Hypa.Infrastructure/Runner/WindowsExecutableResolver.cs
+++ b/src/Hypa.Infrastructure/Runner/WindowsExecutableResolver.cs
@@ -219,14 +219,14 @@ internal static class WindowsExecutableResolver
 
         // Path already has an extension: use as-is when present; do not invent PATHEXT.
         if (HasFileExtension(executable))
-            return File.Exists(candidate) ? Path.GetFullPath(candidate) : null;
+            return FindExistingFileWindows(candidate);
 
         // No extension: try PATHEXT against this path base, then bare file if present.
         foreach (var ext in extensions)
         {
-            var withExt = candidate + ext;
-            if (File.Exists(withExt))
-                return Path.GetFullPath(withExt);
+            var hit = FindExistingFileWindows(candidate + ext);
+            if (hit is not null)
+                return hit;
         }
 
         // Skip extensionless non-PATHEXT matches (often npm bash shims / scripts).
@@ -245,18 +245,67 @@ internal static class WindowsExecutableResolver
         if (HasFileExtension(name))
         {
             var exact = Path.Combine(directory, name);
-            return File.Exists(exact) ? Path.GetFullPath(exact) : null;
+            return FindExistingFileWindows(exact);
         }
 
         // PATHEXT order: prefer .COM, .EXE, … over any extensionless sibling.
         foreach (var ext in extensions)
         {
             var candidate = Path.Combine(directory, name + ext);
-            if (File.Exists(candidate))
-                return Path.GetFullPath(candidate);
+            var hit = FindExistingFileWindows(candidate);
+            if (hit is not null)
+                return hit;
         }
 
         // Intentionally skip bare extensionless files (not safe PE; npm ships bash shims).
+        return null;
+    }
+
+    /// <summary>
+    /// Windows path lookup is case-insensitive. Unit tests exercise this helper on
+    /// Linux (case-sensitive FS) with PATHEXT entries like <c>.CMD</c> against files
+    /// written as <c>.cmd</c> — match case-insensitively so CI mirrors Windows.
+    /// </summary>
+    private static string? FindExistingFileWindows(string candidate)
+    {
+        if (File.Exists(candidate))
+            return Path.GetFullPath(candidate);
+
+        // Native Windows File.Exists is already case-insensitive.
+        if (OperatingSystem.IsWindows())
+            return null;
+
+        string? directory;
+        string fileName;
+        try
+        {
+            directory = Path.GetDirectoryName(candidate);
+            fileName = Path.GetFileName(candidate);
+        }
+        catch
+        {
+            return null;
+        }
+
+        if (string.IsNullOrEmpty(directory) || string.IsNullOrEmpty(fileName))
+            return null;
+
+        if (!Directory.Exists(directory))
+            return null;
+
+        try
+        {
+            foreach (var entry in Directory.EnumerateFiles(directory))
+            {
+                if (string.Equals(Path.GetFileName(entry), fileName, StringComparison.OrdinalIgnoreCase))
+                    return Path.GetFullPath(entry);
+            }
+        }
+        catch
+        {
+            return null;
+        }
+
         return null;
     }
 

--- a/src/Hypa.Infrastructure/Runner/WindowsExecutableResolver.cs
+++ b/src/Hypa.Infrastructure/Runner/WindowsExecutableResolver.cs
@@ -112,19 +112,25 @@ internal static class WindowsExecutableResolver
     }
 
     /// <summary>
-    /// Quote a single argument for inclusion in a cmd.exe command string.
-    /// Empty args and args with whitespace/meta characters are double-quoted;
-    /// embedded quotes are doubled.
+    /// Quote a single argument for inclusion in a cmd.exe <c>/c</c> command string.
+    /// Percent signs are doubled so cmd does not expand env vars before the target
+    /// receives the arg (direct CreateProcess would pass them literally). Empty args
+    /// and args with whitespace/meta characters are double-quoted; embedded quotes
+    /// are doubled; trailing backslashes before the closer are doubled so the quote
+    /// is not escaped.
     /// </summary>
     internal static string QuoteCmdArgument(string argument)
     {
-        if (argument.Length == 0)
+        // cmd expands %VAR% while parsing the /c command line; double percents first.
+        var escaped = argument.Replace("%", "%%", StringComparison.Ordinal);
+
+        if (escaped.Length == 0)
             return "\"\"";
 
         var needsQuoting = false;
-        foreach (var c in argument)
+        foreach (var c in escaped)
         {
-            if (char.IsWhiteSpace(c) || c is '"' or '&' or '|' or '<' or '>' or '^' or '%' or '!' or '(' or ')' or ';')
+            if (char.IsWhiteSpace(c) || c is '"' or '&' or '|' or '<' or '>' or '^' or '!' or '(' or ')' or ';' or ',')
             {
                 needsQuoting = true;
                 break;
@@ -132,16 +138,23 @@ internal static class WindowsExecutableResolver
         }
 
         if (!needsQuoting)
-            return argument;
+            return escaped;
 
-        var sb = new StringBuilder(argument.Length + 2);
+        var sb = new StringBuilder(escaped.Length + 2);
         sb.Append('"');
-        foreach (var c in argument)
+        foreach (var c in escaped)
         {
             if (c == '"')
                 sb.Append('"');
             sb.Append(c);
         }
+
+        // Trailing backslashes would escape the closing quote; double them.
+        var trailingSlashes = 0;
+        for (var i = escaped.Length - 1; i >= 0 && escaped[i] == '\\'; i--)
+            trailingSlashes++;
+        if (trailingSlashes > 0)
+            sb.Append('\\', trailingSlashes);
 
         sb.Append('"');
         return sb.ToString();
@@ -173,17 +186,23 @@ internal static class WindowsExecutableResolver
         string pathEnv,
         IReadOnlyList<string> extensions)
     {
-        // Search working directory first (cmd / CreateProcess convention), then PATH.
-        if (!string.IsNullOrWhiteSpace(workingDirectory))
-        {
-            var hit = FindInDirectory(workingDirectory, name, extensions);
-            if (hit is not null)
-                return hit;
-        }
+        // Effective process cwd: explicit WorkingDirectory, else the host process cwd.
+        // CreateProcess / cmd always search the current directory before PATH.
+        var effectiveCwd = string.IsNullOrWhiteSpace(workingDirectory)
+            ? Directory.GetCurrentDirectory()
+            : workingDirectory;
 
-        foreach (var dir in EnumeratePathDirectories(pathEnv))
+        var hit = FindInDirectory(effectiveCwd, name, extensions);
+        if (hit is not null)
+            return hit;
+
+        foreach (var dir in EnumeratePathDirectories(pathEnv, effectiveCwd))
         {
-            var hit = FindInDirectory(dir, name, extensions);
+            // Already searched effectiveCwd first; skip duplicate empty-PATH hits.
+            if (PathsEqual(dir, effectiveCwd))
+                continue;
+
+            hit = FindInDirectory(dir, name, extensions);
             if (hit is not null)
                 return hit;
         }
@@ -241,15 +260,42 @@ internal static class WindowsExecutableResolver
         return null;
     }
 
-    private static IEnumerable<string> EnumeratePathDirectories(string pathEnv)
+    /// <summary>
+    /// Enumerate PATH directories. Empty segments (leading/trailing/double separators)
+    /// mean the current directory on Windows and are mapped to <paramref name="currentDirectory"/>.
+    /// </summary>
+    private static IEnumerable<string> EnumeratePathDirectories(string pathEnv, string currentDirectory)
     {
         if (string.IsNullOrEmpty(pathEnv))
             yield break;
 
-        foreach (var part in pathEnv.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        // Keep empty entries — on Windows ";." / ";;" / trailing ";" imply cwd.
+        foreach (var raw in pathEnv.Split(Path.PathSeparator))
         {
-            if (part.Length > 0)
-                yield return part;
+            var part = raw.Trim();
+            if (part.Length == 0)
+            {
+                if (!string.IsNullOrEmpty(currentDirectory))
+                    yield return currentDirectory;
+                continue;
+            }
+
+            yield return part;
+        }
+    }
+
+    private static bool PathsEqual(string a, string b)
+    {
+        try
+        {
+            return string.Equals(
+                Path.GetFullPath(a).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                Path.GetFullPath(b).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+        }
+        catch
+        {
+            return string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
         }
     }
 

--- a/src/Hypa.Infrastructure/Runner/WindowsExecutableResolver.cs
+++ b/src/Hypa.Infrastructure/Runner/WindowsExecutableResolver.cs
@@ -69,6 +69,34 @@ internal static class WindowsExecutableResolver
     }
 
     /// <summary>
+    /// Apply a <see cref="SpawnPlan"/> to <paramref name="psi"/> FileName/args.
+    /// Wrapped cmd plans use the raw <see cref="ProcessStartInfo.Arguments"/> string so
+    /// cmd-oriented quotes in the /c payload are not re-escaped by ArgumentList.
+    /// </summary>
+    internal static void ApplySpawnPlan(global::System.Diagnostics.ProcessStartInfo psi, SpawnPlan plan)
+    {
+        psi.FileName = plan.FileName;
+
+        if (plan.WrappedInCmd)
+        {
+            // plan.Arguments is ["/d", "/s", "/c", cmdLine] — cmdLine is already
+            // quoted for cmd.exe and must be passed literally after /c.
+            if (plan.Arguments.Count >= 4)
+            {
+                psi.Arguments = "/d /s /c " + plan.Arguments[3];
+                return;
+            }
+
+            // Fallback: join whatever we got without ArgumentList re-escaping.
+            psi.Arguments = string.Join(' ', plan.Arguments);
+            return;
+        }
+
+        foreach (var arg in plan.Arguments)
+            psi.ArgumentList.Add(arg);
+    }
+
+    /// <summary>
     /// Pure PATH+PATHEXT search. Returns an absolute path when found; otherwise null.
     /// Testable on all platforms (does not check OperatingSystem).
     /// </summary>

--- a/src/Hypa.Infrastructure/Runner/WindowsExecutableResolver.cs
+++ b/src/Hypa.Infrastructure/Runner/WindowsExecutableResolver.cs
@@ -1,0 +1,321 @@
+using System.Text;
+
+namespace Hypa.Infrastructure.Runner;
+
+/// <summary>
+/// PATHEXT-aware Windows executable resolution for direct spawns
+/// (<c>UseShellExecute=false</c>). Resolves only the OS-level FileName/args;
+/// callers must keep the logical <c>CommandInvocation.Executable</c> unchanged
+/// so compressors and filters still match bare names (npm, git, …).
+/// </summary>
+internal static class WindowsExecutableResolver
+{
+    internal static readonly string[] DefaultPathext = [".COM", ".EXE", ".BAT", ".CMD"];
+
+    /// <summary>
+    /// How Process.Start should be invoked after Windows resolution.
+    /// On non-Windows this is always a passthrough of the original values.
+    /// </summary>
+    internal readonly record struct SpawnPlan(
+        string FileName,
+        IReadOnlyList<string> Arguments,
+        bool WrappedInCmd,
+        string? ResolvedPath);
+
+    /// <summary>
+    /// Build a spawn plan for the given executable/args. On non-Windows returns
+    /// the inputs unchanged. On Windows, bare names are resolved via PATH+PATHEXT
+    /// and .cmd/.bat targets are wrapped in <c>cmd.exe /d /s /c</c>.
+    /// </summary>
+    internal static SpawnPlan Resolve(
+        string executable,
+        IReadOnlyList<string> arguments,
+        string? workingDirectory = null,
+        IReadOnlyDictionary<string, string>? envOverrides = null)
+    {
+        if (!OperatingSystem.IsWindows())
+            return new SpawnPlan(executable, arguments, WrappedInCmd: false, ResolvedPath: null);
+
+        if (string.IsNullOrWhiteSpace(executable))
+            return new SpawnPlan(executable, arguments, WrappedInCmd: false, ResolvedPath: null);
+
+        var pathEnv = GetEffectiveEnv("PATH", envOverrides);
+        var pathextEnv = GetEffectiveEnv("PATHEXT", envOverrides);
+        var extensions = ParsePathext(pathextEnv);
+
+        var resolved = ResolvePath(executable, workingDirectory, pathEnv, extensions);
+        if (resolved is null)
+        {
+            // Leave original FileName so Process.Start surfaces a clear error.
+            return new SpawnPlan(executable, arguments, WrappedInCmd: false, ResolvedPath: null);
+        }
+
+        if (IsBatchFile(resolved))
+        {
+            var cmdLine = BuildCmdCArgument(resolved, arguments);
+            return new SpawnPlan(
+                // Absolute cmd path so a restricted EnvOverrides PATH still finds the shell.
+                FileName: GetCmdExePath(),
+                Arguments: ["/d", "/s", "/c", cmdLine],
+                WrappedInCmd: true,
+                ResolvedPath: resolved);
+        }
+
+        return new SpawnPlan(
+            FileName: resolved,
+            Arguments: arguments,
+            WrappedInCmd: false,
+            ResolvedPath: resolved);
+    }
+
+    /// <summary>
+    /// Pure PATH+PATHEXT search. Returns an absolute path when found; otherwise null.
+    /// Testable on all platforms (does not check OperatingSystem).
+    /// </summary>
+    internal static string? ResolvePath(
+        string executable,
+        string? workingDirectory,
+        string pathEnv,
+        IReadOnlyList<string> pathextExtensions)
+    {
+        if (string.IsNullOrWhiteSpace(executable))
+            return null;
+
+        if (HasDirectorySeparator(executable))
+            return ResolvePathWithDirectory(executable, workingDirectory, pathextExtensions);
+
+        return ResolveBareName(executable, workingDirectory, pathEnv, pathextExtensions);
+    }
+
+    internal static bool IsBatchFile(string path)
+    {
+        var ext = Path.GetExtension(path);
+        return ext.Equals(".cmd", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".bat", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Build the single argument passed to <c>cmd.exe /d /s /c</c>: quoted
+    /// executable path plus quoted args, using cmd-safe quoting.
+    /// </summary>
+    internal static string BuildCmdCArgument(string executablePath, IReadOnlyList<string> arguments)
+    {
+        var sb = new StringBuilder();
+        sb.Append(QuoteCmdArgument(executablePath));
+        foreach (var arg in arguments)
+        {
+            sb.Append(' ');
+            sb.Append(QuoteCmdArgument(arg));
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Quote a single argument for inclusion in a cmd.exe command string.
+    /// Empty args and args with whitespace/meta characters are double-quoted;
+    /// embedded quotes are doubled.
+    /// </summary>
+    internal static string QuoteCmdArgument(string argument)
+    {
+        if (argument.Length == 0)
+            return "\"\"";
+
+        var needsQuoting = false;
+        foreach (var c in argument)
+        {
+            if (char.IsWhiteSpace(c) || c is '"' or '&' or '|' or '<' or '>' or '^' or '%' or '!' or '(' or ')' or ';')
+            {
+                needsQuoting = true;
+                break;
+            }
+        }
+
+        if (!needsQuoting)
+            return argument;
+
+        var sb = new StringBuilder(argument.Length + 2);
+        sb.Append('"');
+        foreach (var c in argument)
+        {
+            if (c == '"')
+                sb.Append('"');
+            sb.Append(c);
+        }
+
+        sb.Append('"');
+        return sb.ToString();
+    }
+
+    internal static IReadOnlyList<string> ParsePathext(string? pathextEnv)
+    {
+        if (string.IsNullOrWhiteSpace(pathextEnv))
+            return DefaultPathext;
+
+        var parts = pathextEnv.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length == 0)
+            return DefaultPathext;
+
+        var result = new string[parts.Length];
+        for (var i = 0; i < parts.Length; i++)
+        {
+            var p = parts[i];
+            // PATHEXT entries are normally ".EXE"; tolerate missing leading dots.
+            result[i] = p.StartsWith('.') ? p : "." + p;
+        }
+
+        return result;
+    }
+
+    private static string? ResolveBareName(
+        string name,
+        string? workingDirectory,
+        string pathEnv,
+        IReadOnlyList<string> extensions)
+    {
+        // Search working directory first (cmd / CreateProcess convention), then PATH.
+        if (!string.IsNullOrWhiteSpace(workingDirectory))
+        {
+            var hit = FindInDirectory(workingDirectory, name, extensions);
+            if (hit is not null)
+                return hit;
+        }
+
+        foreach (var dir in EnumeratePathDirectories(pathEnv))
+        {
+            var hit = FindInDirectory(dir, name, extensions);
+            if (hit is not null)
+                return hit;
+        }
+
+        return null;
+    }
+
+    private static string? ResolvePathWithDirectory(
+        string executable,
+        string? workingDirectory,
+        IReadOnlyList<string> extensions)
+    {
+        var candidate = ExpandRelative(executable, workingDirectory);
+
+        // Path already has an extension: use as-is when present; do not invent PATHEXT.
+        if (HasFileExtension(executable))
+            return File.Exists(candidate) ? Path.GetFullPath(candidate) : null;
+
+        // No extension: try PATHEXT against this path base, then bare file if present.
+        foreach (var ext in extensions)
+        {
+            var withExt = candidate + ext;
+            if (File.Exists(withExt))
+                return Path.GetFullPath(withExt);
+        }
+
+        // Skip extensionless non-PATHEXT matches (often npm bash shims / scripts).
+        return null;
+    }
+
+    private static string? FindInDirectory(
+        string directory,
+        string name,
+        IReadOnlyList<string> extensions)
+    {
+        if (string.IsNullOrWhiteSpace(directory))
+            return null;
+
+        // Name already carries an extension (e.g. "tool.exe"): exact match only.
+        if (HasFileExtension(name))
+        {
+            var exact = Path.Combine(directory, name);
+            return File.Exists(exact) ? Path.GetFullPath(exact) : null;
+        }
+
+        // PATHEXT order: prefer .COM, .EXE, … over any extensionless sibling.
+        foreach (var ext in extensions)
+        {
+            var candidate = Path.Combine(directory, name + ext);
+            if (File.Exists(candidate))
+                return Path.GetFullPath(candidate);
+        }
+
+        // Intentionally skip bare extensionless files (not safe PE; npm ships bash shims).
+        return null;
+    }
+
+    private static IEnumerable<string> EnumeratePathDirectories(string pathEnv)
+    {
+        if (string.IsNullOrEmpty(pathEnv))
+            yield break;
+
+        foreach (var part in pathEnv.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (part.Length > 0)
+                yield return part;
+        }
+    }
+
+    private static string ExpandRelative(string path, string? workingDirectory)
+    {
+        if (Path.IsPathRooted(path) || string.IsNullOrWhiteSpace(workingDirectory))
+            return path;
+
+        return Path.Combine(workingDirectory, path);
+    }
+
+    private static bool HasDirectorySeparator(string path) =>
+        path.Contains(Path.DirectorySeparatorChar)
+        || path.Contains(Path.AltDirectorySeparatorChar)
+        // Windows drive-relative like "C:foo" is unusual; rooted "C:\foo" has separators.
+        // Treat "C:\"-style roots via Path.IsPathRooted for absolute paths without further seps? rare.
+        || (path.Length >= 2 && char.IsAsciiLetter(path[0]) && path[1] == ':');
+
+    private static bool HasFileExtension(string path)
+    {
+        // Path.GetExtension returns "" for extensionless and ".exe" for "a.exe".
+        // Names like ".env" are edge cases; treat trailing-dot-something as having an extension.
+        var ext = Path.GetExtension(path);
+        return ext.Length > 0;
+    }
+
+    /// <summary>
+    /// Absolute path to cmd.exe (ComSpec, then SystemDirectory). Avoids depending on PATH
+    /// after EnvOverrides may have replaced it.
+    /// </summary>
+    internal static string GetCmdExePath()
+    {
+        var comSpec = Environment.GetEnvironmentVariable("ComSpec");
+        if (!string.IsNullOrWhiteSpace(comSpec) && File.Exists(comSpec))
+            return comSpec;
+
+        try
+        {
+            var system = Path.Combine(Environment.SystemDirectory, "cmd.exe");
+            if (File.Exists(system))
+                return system;
+        }
+        catch
+        {
+            // SystemDirectory can throw in restricted hosts; fall through.
+        }
+
+        return "cmd.exe";
+    }
+
+    private static string GetEffectiveEnv(
+        string key,
+        IReadOnlyDictionary<string, string>? envOverrides)
+    {
+        if (envOverrides is not null)
+        {
+            if (envOverrides.TryGetValue(key, out var direct))
+                return direct ?? string.Empty;
+
+            foreach (var (k, v) in envOverrides)
+            {
+                if (string.Equals(k, key, StringComparison.OrdinalIgnoreCase))
+                    return v ?? string.Empty;
+            }
+        }
+
+        return Environment.GetEnvironmentVariable(key) ?? string.Empty;
+    }
+}

--- a/tests/Hypa.UnitTests/Infrastructure/WindowsExecutableResolverTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/WindowsExecutableResolverTests.cs
@@ -238,7 +238,7 @@ public sealed class WindowsExecutableResolverTests
         WindowsExecutableResolver.ApplySpawnPlan(psi, plan);
 
         Assert.Equal(@"C:\Windows\System32\cmd.exe", psi.FileName);
-        Assert.Equal(0, psi.ArgumentList.Count);
+        Assert.Empty(psi.ArgumentList);
         Assert.Equal("/d /s /c " + cmdLine, psi.Arguments);
         Assert.Contains(@"C:\Program Files\nodejs\npm.cmd", psi.Arguments, StringComparison.Ordinal);
         Assert.Contains("\"pkg name\"", psi.Arguments, StringComparison.Ordinal);

--- a/tests/Hypa.UnitTests/Infrastructure/WindowsExecutableResolverTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/WindowsExecutableResolverTests.cs
@@ -222,6 +222,48 @@ public sealed class WindowsExecutableResolverTests
     }
 
     [Fact]
+    public void ApplySpawnPlan_WrappedInCmd_UsesRawArgumentsNotArgumentList()
+    {
+        // Regression: ArgumentList re-escapes quotes and breaks "C:\Program Files\…\npm.cmd".
+        var cmdLine = WindowsExecutableResolver.BuildCmdCArgument(
+            @"C:\Program Files\nodejs\npm.cmd",
+            ["install", "pkg name"]);
+        var plan = new WindowsExecutableResolver.SpawnPlan(
+            FileName: @"C:\Windows\System32\cmd.exe",
+            Arguments: ["/d", "/s", "/c", cmdLine],
+            WrappedInCmd: true,
+            ResolvedPath: @"C:\Program Files\nodejs\npm.cmd");
+
+        var psi = new global::System.Diagnostics.ProcessStartInfo();
+        WindowsExecutableResolver.ApplySpawnPlan(psi, plan);
+
+        Assert.Equal(@"C:\Windows\System32\cmd.exe", psi.FileName);
+        Assert.Equal(0, psi.ArgumentList.Count);
+        Assert.Equal("/d /s /c " + cmdLine, psi.Arguments);
+        Assert.Contains(@"C:\Program Files\nodejs\npm.cmd", psi.Arguments, StringComparison.Ordinal);
+        Assert.Contains("\"pkg name\"", psi.Arguments, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ApplySpawnPlan_Direct_UsesArgumentList()
+    {
+        var plan = new WindowsExecutableResolver.SpawnPlan(
+            FileName: @"C:\tools\widget.exe",
+            Arguments: ["-v", "a b"],
+            WrappedInCmd: false,
+            ResolvedPath: @"C:\tools\widget.exe");
+
+        var psi = new global::System.Diagnostics.ProcessStartInfo();
+        WindowsExecutableResolver.ApplySpawnPlan(psi, plan);
+
+        Assert.Equal(@"C:\tools\widget.exe", psi.FileName);
+        Assert.Equal(2, psi.ArgumentList.Count);
+        Assert.Equal("-v", psi.ArgumentList[0]);
+        Assert.Equal("a b", psi.ArgumentList[1]);
+        Assert.True(string.IsNullOrEmpty(psi.Arguments));
+    }
+
+    [Fact]
     public void Resolve_NonWindows_IsPassthrough()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/Hypa.UnitTests/Infrastructure/WindowsExecutableResolverTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/WindowsExecutableResolverTests.cs
@@ -1,0 +1,337 @@
+using Hypa.Infrastructure.Runner;
+using Hypa.Runtime.Domain.Runner;
+using Xunit;
+
+namespace Hypa.UnitTests.Infrastructure;
+
+public sealed class WindowsExecutableResolverTests
+{
+    private static readonly string[] DefaultExt = [".COM", ".EXE", ".BAT", ".CMD"];
+
+    [Fact]
+    public void ResolvePath_PrefersCmdOverExtensionlessSibling()
+    {
+        using var fixture = PathFixture.Create();
+        fixture.Write("fake-tool", "#!/bin/sh\necho bare\n");
+        fixture.Write("fake-tool.cmd", "@echo marker-cmd\n");
+
+        var resolved = WindowsExecutableResolver.ResolvePath(
+            "fake-tool",
+            workingDirectory: null,
+            pathEnv: fixture.Directory,
+            pathextExtensions: DefaultExt);
+
+        Assert.NotNull(resolved);
+        Assert.EndsWith("fake-tool.cmd", resolved, StringComparison.OrdinalIgnoreCase);
+        Assert.True(WindowsExecutableResolver.IsBatchFile(resolved!));
+    }
+
+    [Fact]
+    public void ResolvePath_PrefersExeOverCmd_ByPathextOrder()
+    {
+        using var fixture = PathFixture.Create();
+        fixture.Write("fake-tool.cmd", "@echo from-cmd\n");
+        fixture.Write("fake-tool.exe", "not-a-real-pe");
+
+        var resolved = WindowsExecutableResolver.ResolvePath(
+            "fake-tool",
+            workingDirectory: null,
+            pathEnv: fixture.Directory,
+            pathextExtensions: DefaultExt);
+
+        Assert.NotNull(resolved);
+        Assert.EndsWith("fake-tool.exe", resolved, StringComparison.OrdinalIgnoreCase);
+        Assert.False(WindowsExecutableResolver.IsBatchFile(resolved!));
+    }
+
+    [Fact]
+    public void ResolvePath_ExtensionlessOnly_ReturnsNull()
+    {
+        using var fixture = PathFixture.Create();
+        fixture.Write("lonely-shim", "#!/bin/sh\necho no\n");
+
+        var resolved = WindowsExecutableResolver.ResolvePath(
+            "lonely-shim",
+            workingDirectory: null,
+            pathEnv: fixture.Directory,
+            pathextExtensions: DefaultExt);
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void ResolvePath_ExactExtensionMatch_FindsExe()
+    {
+        using var fixture = PathFixture.Create();
+        fixture.Write("tool.exe", "pe");
+        fixture.Write("tool.cmd", "@echo cmd\n");
+
+        var resolved = WindowsExecutableResolver.ResolvePath(
+            "tool.exe",
+            workingDirectory: null,
+            pathEnv: fixture.Directory,
+            pathextExtensions: DefaultExt);
+
+        Assert.NotNull(resolved);
+        Assert.EndsWith("tool.exe", resolved, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ResolvePath_SearchesWorkingDirectoryBeforePath()
+    {
+        using var cwd = PathFixture.Create();
+        using var pathDir = PathFixture.Create();
+        cwd.Write("tool.cmd", "@echo from-cwd\n");
+        pathDir.Write("tool.cmd", "@echo from-path\n");
+
+        var resolved = WindowsExecutableResolver.ResolvePath(
+            "tool",
+            workingDirectory: cwd.Directory,
+            pathEnv: pathDir.Directory,
+            pathextExtensions: DefaultExt);
+
+        Assert.NotNull(resolved);
+        Assert.StartsWith(cwd.Directory, resolved!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ResolvePath_PathWithDirectory_NoExtension_AppliesPathext()
+    {
+        using var fixture = PathFixture.Create();
+        fixture.Write("nested.cmd", "@echo nested\n");
+        var basePath = Path.Combine(fixture.Directory, "nested");
+
+        var resolved = WindowsExecutableResolver.ResolvePath(
+            basePath,
+            workingDirectory: null,
+            pathEnv: string.Empty,
+            pathextExtensions: DefaultExt);
+
+        Assert.NotNull(resolved);
+        Assert.EndsWith("nested.cmd", resolved, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ResolvePath_PathWithDirectoryAndExtension_DoesNotInventPathext()
+    {
+        using var fixture = PathFixture.Create();
+        fixture.Write("tool.cmd", "@echo cmd\n");
+        var wrong = Path.Combine(fixture.Directory, "tool.exe");
+
+        var resolved = WindowsExecutableResolver.ResolvePath(
+            wrong,
+            workingDirectory: null,
+            pathEnv: string.Empty,
+            pathextExtensions: DefaultExt);
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void ParsePathext_DefaultWhenEmpty()
+    {
+        var parsed = WindowsExecutableResolver.ParsePathext(null);
+        Assert.Equal(WindowsExecutableResolver.DefaultPathext, parsed);
+
+        parsed = WindowsExecutableResolver.ParsePathext("");
+        Assert.Equal(WindowsExecutableResolver.DefaultPathext, parsed);
+    }
+
+    [Fact]
+    public void ParsePathext_NormalizesMissingDots()
+    {
+        var parsed = WindowsExecutableResolver.ParsePathext(".EXE;BAT;cmd");
+        Assert.Equal([".EXE", ".BAT", ".cmd"], parsed);
+    }
+
+    [Fact]
+    public void QuoteCmdArgument_QuotesSpacesAndEmpty()
+    {
+        Assert.Equal("\"\"", WindowsExecutableResolver.QuoteCmdArgument(""));
+        Assert.Equal("plain", WindowsExecutableResolver.QuoteCmdArgument("plain"));
+        Assert.Equal("\"a b\"", WindowsExecutableResolver.QuoteCmdArgument("a b"));
+        Assert.Equal("\"say \"\"hi\"\"\"", WindowsExecutableResolver.QuoteCmdArgument("say \"hi\""));
+    }
+
+    [Fact]
+    public void BuildCmdCArgument_IncludesQuotedExecutableAndArgs()
+    {
+        var line = WindowsExecutableResolver.BuildCmdCArgument(
+            @"C:\Program Files\tool.cmd",
+            ["install", "pkg name"]);
+
+        Assert.Equal("\"C:\\Program Files\\tool.cmd\" install \"pkg name\"", line);
+    }
+
+    [Fact]
+    public void Resolve_NonWindows_IsPassthrough()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // passthrough path is for non-Windows hosts
+
+        var plan = WindowsExecutableResolver.Resolve("npm", ["install"], workingDirectory: null, envOverrides: null);
+        Assert.Equal("npm", plan.FileName);
+        Assert.Equal(["install"], plan.Arguments);
+        Assert.False(plan.WrappedInCmd);
+        Assert.Null(plan.ResolvedPath);
+    }
+
+    [Fact]
+    public void Resolve_Windows_WrapsCmdAndPreservesLogicalNameSeparately()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        using var fixture = PathFixture.Create();
+        fixture.Write("fake-tool.cmd", "@echo marker-from-cmd\r\n");
+
+        var env = new Dictionary<string, string>
+        {
+            ["PATH"] = fixture.Directory,
+            ["PATHEXT"] = ".COM;.EXE;.BAT;.CMD",
+        };
+
+        var plan = WindowsExecutableResolver.Resolve(
+            "fake-tool",
+            ["arg1"],
+            workingDirectory: null,
+            envOverrides: env);
+
+        Assert.True(plan.WrappedInCmd);
+        Assert.True(
+            plan.FileName.EndsWith("cmd.exe", StringComparison.OrdinalIgnoreCase),
+            $"Expected cmd.exe path, got: {plan.FileName}");
+        Assert.Equal(4, plan.Arguments.Count);
+        Assert.Equal("/d", plan.Arguments[0]);
+        Assert.Equal("/s", plan.Arguments[1]);
+        Assert.Equal("/c", plan.Arguments[2]);
+        Assert.Contains("fake-tool.cmd", plan.Arguments[3], StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("arg1", plan.Arguments[3], StringComparison.Ordinal);
+
+        // Logical invocation name stays bare for compressors.
+        var inv = CommandInvocation.Buffered("fake-tool", ["arg1"], "fake-tool arg1");
+        Assert.Equal("fake-tool", inv.Executable);
+    }
+
+    [Fact]
+    public void Resolve_Windows_ExeNotWrapped()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        using var fixture = PathFixture.Create();
+        // Real PE not required for resolution; existence is enough.
+        fixture.Write("widget.exe", "x");
+
+        var env = new Dictionary<string, string>
+        {
+            ["PATH"] = fixture.Directory,
+            ["PATHEXT"] = ".COM;.EXE;.BAT;.CMD",
+        };
+
+        var plan = WindowsExecutableResolver.Resolve(
+            "widget",
+            ["-v"],
+            workingDirectory: null,
+            envOverrides: env);
+
+        Assert.False(plan.WrappedInCmd);
+        Assert.NotNull(plan.ResolvedPath);
+        Assert.EndsWith("widget.exe", plan.FileName, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(["-v"], plan.Arguments);
+    }
+
+    [Fact]
+    public async Task ProcessCommandRunner_Windows_SpawnsCmdShimAndCapturesStdout()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        using var fixture = PathFixture.Create();
+        fixture.Write("fake-tool", "not-executable-shim");
+        fixture.Write("fake-tool.cmd", "@echo marker-cmd\r\n");
+
+        var runner = new ProcessCommandRunner();
+        var inv = new CommandInvocation
+        {
+            Executable = "fake-tool",
+            Arguments = [],
+            OriginalCommand = "fake-tool",
+            Mode = ToolRunMode.Buffered,
+            Timeout = TimeSpan.FromSeconds(10),
+            EnvOverrides = new Dictionary<string, string>
+            {
+                ["PATH"] = fixture.Directory,
+                ["PATHEXT"] = ".COM;.EXE;.BAT;.CMD",
+            },
+        };
+
+        var result = await runner.RunAsync(inv, CancellationToken.None);
+        Assert.True(result.IsOk, result.IsOk ? "" : result.Error.Message);
+        Assert.Contains("marker-cmd", result.Value.Stdout);
+        Assert.Equal(0, result.Value.ExitCode);
+        // Logical executable preserved for filters/compressors.
+        Assert.Equal("fake-tool", inv.Executable);
+    }
+
+    [Fact]
+    public async Task ProcessCommandRunner_Windows_MissingBareName_FailsStartClearly()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        using var fixture = PathFixture.Create();
+        fixture.Write("lonely-shim", "not-a-pe");
+
+        var runner = new ProcessCommandRunner();
+        var inv = new CommandInvocation
+        {
+            Executable = "lonely-shim",
+            Arguments = [],
+            OriginalCommand = "lonely-shim",
+            Mode = ToolRunMode.Buffered,
+            Timeout = TimeSpan.FromSeconds(5),
+            EnvOverrides = new Dictionary<string, string>
+            {
+                ["PATH"] = fixture.Directory,
+                ["PATHEXT"] = ".COM;.EXE;.BAT;.CMD",
+            },
+        };
+
+        var result = await runner.RunAsync(inv, CancellationToken.None);
+        Assert.False(result.IsOk);
+        Assert.Equal("PROCESS_START_FAILED", result.Error.Code);
+    }
+
+    private sealed class PathFixture : IDisposable
+    {
+        public string Directory { get; }
+
+        private PathFixture(string directory) => Directory = directory;
+
+        public static PathFixture Create()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "hypa-pathext-" + Guid.NewGuid().ToString("N"));
+            System.IO.Directory.CreateDirectory(dir);
+            return new PathFixture(dir);
+        }
+
+        public void Write(string name, string contents)
+        {
+            File.WriteAllText(Path.Combine(Directory, name), contents);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (System.IO.Directory.Exists(Directory))
+                    System.IO.Directory.Delete(Directory, recursive: true);
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
+        }
+    }
+}

--- a/tests/Hypa.UnitTests/Infrastructure/WindowsExecutableResolverTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/WindowsExecutableResolverTests.cs
@@ -154,6 +154,21 @@ public sealed class WindowsExecutableResolverTests
     }
 
     [Fact]
+    public void QuoteCmdArgument_DoublesPercentToPreventEnvExpansion()
+    {
+        // Direct CreateProcess would pass %PATH% literally; cmd would expand it.
+        Assert.Equal("%%PATH%%", WindowsExecutableResolver.QuoteCmdArgument("%PATH%"));
+        Assert.Equal("\"a %%b%% c\"", WindowsExecutableResolver.QuoteCmdArgument("a %b% c"));
+    }
+
+    [Fact]
+    public void QuoteCmdArgument_DoublesTrailingBackslashBeforeClosingQuote()
+    {
+        // Spaces force quoting; trailing \ must be doubled so it does not escape the closer.
+        Assert.Equal("\"C:\\Program Files\\tool\\\\\"", WindowsExecutableResolver.QuoteCmdArgument(@"C:\Program Files\tool\"));
+    }
+
+    [Fact]
     public void BuildCmdCArgument_IncludesQuotedExecutableAndArgs()
     {
         var line = WindowsExecutableResolver.BuildCmdCArgument(
@@ -161,6 +176,49 @@ public sealed class WindowsExecutableResolverTests
             ["install", "pkg name"]);
 
         Assert.Equal("\"C:\\Program Files\\tool.cmd\" install \"pkg name\"", line);
+    }
+
+    [Fact]
+    public void ResolvePath_SearchesProcessCwdWhenWorkingDirectoryNull()
+    {
+        using var fixture = PathFixture.Create();
+        fixture.Write("cwd-tool.cmd", "@echo from-process-cwd\n");
+
+        var previous = Directory.GetCurrentDirectory();
+        try
+        {
+            Directory.SetCurrentDirectory(fixture.Directory);
+            var resolved = WindowsExecutableResolver.ResolvePath(
+                "cwd-tool",
+                workingDirectory: null,
+                pathEnv: "/nonexistent-path-xyz",
+                pathextExtensions: DefaultExt);
+
+            Assert.NotNull(resolved);
+            Assert.EndsWith("cwd-tool.cmd", resolved, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(previous);
+        }
+    }
+
+    [Fact]
+    public void ResolvePath_EmptyPathSegmentMeansCurrentDirectory()
+    {
+        using var fixture = PathFixture.Create();
+        fixture.Write("empty-seg.cmd", "@echo empty-seg\n");
+
+        // Leading empty segment: ";C:\other" → cwd then other.
+        var pathEnv = Path.PathSeparator + Path.Combine(Path.GetTempPath(), "no-such-hypa-dir");
+        var resolved = WindowsExecutableResolver.ResolvePath(
+            "empty-seg",
+            workingDirectory: fixture.Directory,
+            pathEnv: pathEnv,
+            pathextExtensions: DefaultExt);
+
+        Assert.NotNull(resolved);
+        Assert.EndsWith("empty-seg.cmd", resolved, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

On Windows, direct spawns used `UseShellExecute=false` with bare command names and never applied PATHEXT. CreateProcess cannot run npm-style `.cmd`/extensionless shims, so tools like `npm` failed while the shell path (`cmd.exe /c`) worked.

This change resolves bare executable names with PATH + PATHEXT order inside `ProcessCommandRunner` before `Process.Start`, and wraps resolved `.cmd`/`.bat` targets via `cmd.exe /d /s /c` so stdout/stderr redirection still works. Logical `CommandInvocation.Executable` is left unchanged so compressors and filters continue to match bare names (`npm`, `git`, …).

Non-Windows behavior is unchanged. Git `usr\bin` PATH injection is intentionally out of scope.

### Implementation notes
- New `WindowsExecutableResolver` (internal) performs PATH/PATHEXT search and spawn planning.
- Effective cwd is always searched (explicit `WorkingDirectory` or process cwd); empty PATH segments mean cwd.
- Batch wrap uses absolute ComSpec/`SystemDirectory\cmd.exe` so restricted `EnvOverrides` PATH still finds the shell.
- Cmd `/c` argument quoting doubles `%` (no env expansion) and trailing backslashes before the closer.

## Test plan
- [x] `dotnet test tests/Hypa.UnitTests --filter "FullyQualifiedName~WindowsExecutableResolver|FullyQualifiedName~ProcessCommandRunner"` — 28 passed
- [x] Unit fixtures cover: prefer `.cmd` over extensionless sibling, prefer `.exe` over `.cmd`, extensionless-only → null, cwd-first, empty PATH segment, path-with-dir PATHEXT, quote/`%`/trailing-`\` rules, non-Windows passthrough
- [x] Windows-gated spawn Facts for live `.cmd` capture and clear start failure (run on Windows CI/agents)
- Unrelated pre-existing failure elsewhere: `CodeStructureProviderRegistryTests.Select_ForMarkdown_ReturnsMarkdownProvider` (not touched by this PR)

## Codex review
- Model: **gpt-5.6-luna** with `model_reasoning_effort=xhigh`, read-only sandbox
- Initial verdict: **fail** (2 open bugs: cwd/empty-PATH search; cmd quoting)
- Fixes committed; **final verdict: pass_after_fix**, open bug-severity items: **0**

Closes #74
