### PR TITLE
Fix hypa_read dumping images as binary text

### DIFF
--- a/packages/pi-hypa/extensions/tools.ts
+++ b/packages/pi-hypa/extensions/tools.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { access, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
 import { homedir, platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import { Text } from "@earendil-works/pi-tui";
@@ -7,6 +8,15 @@ import { getExecArgs } from "./rewrite-client.js";
 
 const DEFAULT_MAX_BYTES = 50 * 1024;
 const DEFAULT_MAX_LINES = 2000;
+/** Max raw image bytes attached inline (base64 grows ~4/3). Beyond this we note and omit the image part. */
+const MAX_INLINE_IMAGE_BYTES = 5 * 1024 * 1024;
+const IMAGE_TYPE_SNIFF_BYTES = 4100;
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] as const;
+
+type PiToolTextPart = { type: "text"; text: string };
+type PiToolImagePart = { type: "image"; data: string; mimeType: string };
+type PiToolContentPart = PiToolTextPart | PiToolImagePart;
+type PiToolResult = { content: PiToolContentPart[]; details?: unknown };
 
 type PiToolParams = Record<string, any>;
 type PiToolExecute = (
@@ -15,7 +25,7 @@ type PiToolExecute = (
   signal?: AbortSignal,
   onUpdate?: unknown,
   ctx?: unknown,
-) => Promise<{ content: Array<{ type: "text"; text: string }>; details?: unknown }>;
+) => Promise<PiToolResult>;
 
 type PiApi = {
   exec(command: string, args: string[], options?: Record<string, unknown>): Promise<HypaExecResult>;
@@ -184,6 +194,163 @@ export function buildReadCommand(path: string, offset?: number, limit?: number):
     return `sed -n ${shellQuote(`${start},${end}p`)} -- ${quotedPath}`;
   }
   return `cat -- ${quotedPath}`;
+}
+
+/**
+ * Detect supported raster image MIME types from magic bytes (not file extension).
+ * Parity with Pi coding-agent mime sniff for png/jpeg/gif/webp.
+ */
+export function detectSupportedImageMimeType(buffer: Uint8Array | Buffer): string | null {
+  if (startsWithBytes(buffer, [0xff, 0xd8, 0xff])) {
+    // JPEG-LS (0xF7) is not a standard vision attachment; treat as unsupported.
+    return buffer.length > 3 && buffer[3] === 0xf7 ? null : "image/jpeg";
+  }
+  if (startsWithBytes(buffer, PNG_SIGNATURE)) {
+    return isStaticPng(buffer) ? "image/png" : null;
+  }
+  if (startsWithAscii(buffer, 0, "GIF87a") || startsWithAscii(buffer, 0, "GIF89a")) {
+    return "image/gif";
+  }
+  if (startsWithAscii(buffer, 0, "RIFF") && startsWithAscii(buffer, 8, "WEBP")) {
+    return "image/webp";
+  }
+  return null;
+}
+
+/** True when the buffer looks like opaque binary (not a supported image, not plain text). */
+export function looksLikeOpaqueBinary(buffer: Uint8Array | Buffer): boolean {
+  if (detectSupportedImageMimeType(buffer)) return false;
+  const sample = buffer.subarray(0, Math.min(buffer.length, IMAGE_TYPE_SNIFF_BYTES));
+  for (let i = 0; i < sample.length; i++) {
+    if (sample[i] === 0) return true;
+  }
+  return false;
+}
+
+function startsWithBytes(buffer: Uint8Array | Buffer, bytes: readonly number[]): boolean {
+  if (buffer.length < bytes.length) return false;
+  for (let i = 0; i < bytes.length; i++) {
+    if (buffer[i] !== bytes[i]) return false;
+  }
+  return true;
+}
+
+function startsWithAscii(buffer: Uint8Array | Buffer, offset: number, text: string): boolean {
+  if (buffer.length < offset + text.length) return false;
+  for (let i = 0; i < text.length; i++) {
+    if (buffer[offset + i] !== text.charCodeAt(i)) return false;
+  }
+  return true;
+}
+
+function readUint32BE(buffer: Uint8Array | Buffer, offset: number): number {
+  return (
+    ((buffer[offset] ?? 0) * 0x1000000 +
+      ((buffer[offset + 1] ?? 0) << 16) +
+      ((buffer[offset + 2] ?? 0) << 8) +
+      (buffer[offset + 3] ?? 0)) >>>
+    0
+  );
+}
+
+/** Accept standard static PNG (IHDR); reject animated PNG (acTL before IDAT) like Pi. */
+function isStaticPng(buffer: Uint8Array | Buffer): boolean {
+  if (buffer.length < 24) return false;
+  // IHDR length must be 13 and type "IHDR"
+  if (readUint32BE(buffer, PNG_SIGNATURE.length) !== 13) return false;
+  if (!startsWithAscii(buffer, 12, "IHDR")) return false;
+
+  let offset: number = PNG_SIGNATURE.length;
+  while (offset + 8 <= buffer.length) {
+    const chunkLength = readUint32BE(buffer, offset);
+    const typeOffset = offset + 4;
+    if (startsWithAscii(buffer, typeOffset, "acTL")) return false;
+    if (startsWithAscii(buffer, typeOffset, "IDAT")) return true;
+    const next = offset + 8 + chunkLength + 4;
+    if (next <= offset || next > buffer.length) return true; // incomplete sniff → allow
+    offset = next;
+  }
+  return true;
+}
+
+function getNonVisionImageNote(ctx: unknown): string | undefined {
+  const model = (ctx as { model?: { input?: unknown } } | null | undefined)?.model;
+  const input = model?.input;
+  if (!model || (Array.isArray(input) && input.includes("image"))) {
+    return undefined;
+  }
+  // Model present but no image modality advertised.
+  if (model && Array.isArray(input) && !input.includes("image")) {
+    return "[Current model does not support images. The image will be omitted from this request.]";
+  }
+  return undefined;
+}
+
+/**
+ * If path points at a supported image (magic-byte sniff), build multimodal tool content.
+ * Returns null when the file should go through the normal text read path.
+ */
+export async function tryBuildImageReadResult(
+  path: string,
+  ctx?: unknown,
+): Promise<PiToolResult | null> {
+  const resolved = normalizePathArg(path);
+  try {
+    await access(resolved, constants.R_OK);
+  } catch {
+    return null; // missing/unreadable → fall through so Hypa CLI can report the error
+  }
+
+  let bytes: Buffer;
+  try {
+    bytes = await readFile(resolved);
+  } catch {
+    return null;
+  }
+
+  const mimeType = detectSupportedImageMimeType(bytes);
+  if (!mimeType) {
+    if (looksLikeOpaqueBinary(bytes)) {
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `SUMMARY\nFile: ${path}\n\nDETAILS\n` +
+              `Binary file detected (${formatSize(bytes.length)}); not decoded as text. ` +
+              `Supported image formats (png/jpeg/gif/webp) are attached as vision content when recognized by content sniffing.`,
+          },
+        ],
+        details: { source: "hypa-read-binary", path: resolved, size: bytes.length },
+      };
+    }
+    return null;
+  }
+
+  const nonVisionNote = getNonVisionImageNote(ctx);
+  let textNote = `Read image file [${mimeType}] (${formatSize(bytes.length)})`;
+  const content: PiToolContentPart[] = [];
+
+  if (bytes.length > MAX_INLINE_IMAGE_BYTES) {
+    textNote +=
+      `\n[Image omitted: ${formatSize(bytes.length)} exceeds inline limit of ${formatSize(MAX_INLINE_IMAGE_BYTES)}. ` +
+      `Use a smaller asset or host-side resize.]`;
+    if (nonVisionNote) textNote += `\n${nonVisionNote}`;
+    content.push({ type: "text", text: textNote });
+    return { content, details: { source: "hypa-read-image", mimeType, omitted: true, size: bytes.length } };
+  }
+
+  if (nonVisionNote) textNote += `\n${nonVisionNote}`;
+  content.push({ type: "text", text: textNote });
+  content.push({
+    type: "image",
+    data: bytes.toString("base64"),
+    mimeType,
+  });
+  return {
+    content,
+    details: { source: "hypa-read-image", mimeType, size: bytes.length },
+  };
 }
 
 export function buildGrepCommand(params: {
@@ -360,7 +527,7 @@ function previewResultText(result: any, options: { expanded?: boolean; isPartial
   return new Text(`${preview}${hint}`, 0, 0);
 }
 
-async function toToolText(result: HypaExecResult, command: string, preferTail = false) {
+async function toToolText(result: HypaExecResult, command: string, preferTail = false): Promise<PiToolResult> {
   const combined = [result.stdout, result.stderr].filter((part) => part?.length > 0).join(result.stdout && result.stderr ? "\n" : "");
   const truncation = preferTail
     ? truncateText(combined, true)
@@ -418,11 +585,20 @@ export function registerHypaTools(pi: PiApi, config: HypaPiConfig) {
   pi.registerTool({
     name: "hypa_read",
     label: "hypa_read",
-    description: `Read a file through Hypa compression. Supports offset/limit line slices. Output is truncated to ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)} with full output saved when needed.`,
-    promptSnippet: "Read file contents through Hypa compression",
-    promptGuidelines: ["Use hypa_read to inspect file contents instead of cat/head/tail via shell."],
+    description: `Read a file through Hypa compression. Supports text (offset/limit line slices) and images (png/jpeg/gif/webp via content sniffing → vision attachments). Text output is truncated to ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)} with full output saved when needed.`,
+    promptSnippet: "Read file contents through Hypa compression (text or images)",
+    promptGuidelines: [
+      "Use hypa_read to inspect file contents instead of cat/head/tail via shell.",
+      "Image files are returned as vision image attachments (magic-byte detection), not text dumps.",
+    ],
     parameters: readSchema,
-    async execute(_toolCallId, params, signal, _onUpdate, _ctx) {
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      // Images: attach vision content (do not shell-cat binary → mojibake). Offset/limit are ignored for images/binary.
+      if (typeof params.path === "string") {
+        const imageResult = await tryBuildImageReadResult(params.path, ctx);
+        if (imageResult) return imageResult;
+      }
+
       const command = buildReadCommand(params.path, params.offset, params.limit);
       const timeoutMs = params.maxTokens ? undefined : undefined;
       const result = await runHypaCommand(pi, config, command, timeoutMs, false, signal);

--- a/packages/pi-hypa/extensions/tools.ts
+++ b/packages/pi-hypa/extensions/tools.ts
@@ -1,4 +1,4 @@
-import { access, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { access, mkdtemp, open, readFile, stat, writeFile } from "node:fs/promises";
 import { constants } from "node:fs";
 import { homedir, platform, tmpdir } from "node:os";
 import { join } from "node:path";
@@ -289,6 +289,9 @@ function getNonVisionImageNote(ctx: unknown): string | undefined {
 /**
  * If path points at a supported image (magic-byte sniff), build multimodal tool content.
  * Returns null when the file should go through the normal text read path.
+ *
+ * Sniffs only the leading {@link IMAGE_TYPE_SNIFF_BYTES} first so ordinary text reads
+ * do not load the full file into memory before falling through to the Hypa CLI path.
  */
 export async function tryBuildImageReadResult(
   path: string,
@@ -301,6 +304,66 @@ export async function tryBuildImageReadResult(
     return null; // missing/unreadable → fall through so Hypa CLI can report the error
   }
 
+  let sniff: Buffer;
+  try {
+    const handle = await open(resolved, "r");
+    try {
+      const buf = Buffer.alloc(IMAGE_TYPE_SNIFF_BYTES);
+      const { bytesRead } = await handle.read(buf, 0, IMAGE_TYPE_SNIFF_BYTES, 0);
+      sniff = buf.subarray(0, bytesRead);
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return null;
+  }
+
+  const mimeType = detectSupportedImageMimeType(sniff);
+  if (!mimeType) {
+    if (looksLikeOpaqueBinary(sniff)) {
+      let size = sniff.length;
+      try {
+        size = (await stat(resolved)).size;
+      } catch {
+        /* use sniff length */
+      }
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `SUMMARY\nFile: ${path}\n\nDETAILS\n` +
+              `Binary file detected (${formatSize(size)}); not decoded as text. ` +
+              `Supported image formats (png/jpeg/gif/webp) are attached as vision content when recognized by content sniffing.`,
+          },
+        ],
+        details: { source: "hypa-read-binary", path: resolved, size },
+      };
+    }
+    return null;
+  }
+
+  let fileSize: number;
+  try {
+    fileSize = (await stat(resolved)).size;
+  } catch {
+    fileSize = sniff.length;
+  }
+
+  const nonVisionNote = getNonVisionImageNote(ctx);
+  let textNote = `Read image file [${mimeType}] (${formatSize(fileSize)})`;
+  const content: PiToolContentPart[] = [];
+
+  if (fileSize > MAX_INLINE_IMAGE_BYTES) {
+    textNote +=
+      `\n[Image omitted: ${formatSize(fileSize)} exceeds inline limit of ${formatSize(MAX_INLINE_IMAGE_BYTES)}. ` +
+      `Use a smaller asset or host-side resize.]`;
+    if (nonVisionNote) textNote += `\n${nonVisionNote}`;
+    content.push({ type: "text", text: textNote });
+    return { content, details: { source: "hypa-read-image", mimeType, omitted: true, size: fileSize } };
+  }
+
+  // Full read only after image sniff confirms a supported raster format.
   let bytes: Buffer;
   try {
     bytes = await readFile(resolved);
@@ -308,48 +371,19 @@ export async function tryBuildImageReadResult(
     return null;
   }
 
-  const mimeType = detectSupportedImageMimeType(bytes);
-  if (!mimeType) {
-    if (looksLikeOpaqueBinary(bytes)) {
-      return {
-        content: [
-          {
-            type: "text",
-            text:
-              `SUMMARY\nFile: ${path}\n\nDETAILS\n` +
-              `Binary file detected (${formatSize(bytes.length)}); not decoded as text. ` +
-              `Supported image formats (png/jpeg/gif/webp) are attached as vision content when recognized by content sniffing.`,
-          },
-        ],
-        details: { source: "hypa-read-binary", path: resolved, size: bytes.length },
-      };
-    }
-    return null;
-  }
-
-  const nonVisionNote = getNonVisionImageNote(ctx);
-  let textNote = `Read image file [${mimeType}] (${formatSize(bytes.length)})`;
-  const content: PiToolContentPart[] = [];
-
-  if (bytes.length > MAX_INLINE_IMAGE_BYTES) {
-    textNote +=
-      `\n[Image omitted: ${formatSize(bytes.length)} exceeds inline limit of ${formatSize(MAX_INLINE_IMAGE_BYTES)}. ` +
-      `Use a smaller asset or host-side resize.]`;
-    if (nonVisionNote) textNote += `\n${nonVisionNote}`;
-    content.push({ type: "text", text: textNote });
-    return { content, details: { source: "hypa-read-image", mimeType, omitted: true, size: bytes.length } };
-  }
+  // Re-validate full buffer (defends against truncated/racey files between sniff and read).
+  const fullMime = detectSupportedImageMimeType(bytes) ?? mimeType;
 
   if (nonVisionNote) textNote += `\n${nonVisionNote}`;
   content.push({ type: "text", text: textNote });
   content.push({
     type: "image",
     data: bytes.toString("base64"),
-    mimeType,
+    mimeType: fullMime,
   });
   return {
     content,
-    details: { source: "hypa-read-image", mimeType, size: bytes.length },
+    details: { source: "hypa-read-image", mimeType: fullMime, size: bytes.length },
   };
 }
 

--- a/packages/pi-hypa/test/tools.test.ts
+++ b/packages/pi-hypa/test/tools.test.ts
@@ -1,7 +1,19 @@
 import test from "node:test";
-import { homedir } from "node:os";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
 import assert from "node:assert/strict";
-import { buildFindCommand, buildGrepCommand, buildLsCommand, buildReadCommand, limitStdoutLines, shellQuote } from "../extensions/tools.js";
+import {
+  buildFindCommand,
+  buildGrepCommand,
+  buildLsCommand,
+  buildReadCommand,
+  detectSupportedImageMimeType,
+  limitStdoutLines,
+  looksLikeOpaqueBinary,
+  shellQuote,
+  tryBuildImageReadResult,
+} from "../extensions/tools.js";
 
 test("shellQuote protects spaces and single quotes on POSIX", () => {
   assert.equal(shellQuote("simple/path", "linux"), "simple/path");
@@ -113,4 +125,107 @@ test("normalizePathArg leaves ~user, absolute, and relative paths untouched", ()
 test("buildLsCommand defaults to long listing", () => {
   assert.equal(buildLsCommand({ path: ".", all: true }), "ls -la -- .");
   assert.equal(buildLsCommand({ path: "src", long: false }), "ls -- src");
+});
+
+// Minimal valid static PNG (1x1 transparent) with IHDR + IDAT + IEND
+const MINI_PNG = Buffer.from(
+  "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c63000100000500010d0a2db40000000049454e44ae426082",
+  "hex",
+);
+const MINI_JPEG = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0xff, 0xd9]);
+const MINI_GIF = Buffer.from("GIF89a\x01\x00\x01\x00\x00\x00\x00;", "binary");
+const MINI_WEBP = Buffer.from(
+  // RIFF....WEBP + minimal payload
+  Buffer.concat([
+    Buffer.from("RIFF"),
+    Buffer.from([0x0a, 0x00, 0x00, 0x00]),
+    Buffer.from("WEBP"),
+    Buffer.from("XXXX"),
+  ]),
+);
+
+test("detectSupportedImageMimeType sniffs png/jpeg/gif/webp magic bytes", () => {
+  assert.equal(detectSupportedImageMimeType(MINI_PNG), "image/png");
+  assert.equal(detectSupportedImageMimeType(MINI_JPEG), "image/jpeg");
+  assert.equal(detectSupportedImageMimeType(MINI_GIF), "image/gif");
+  assert.equal(detectSupportedImageMimeType(MINI_WEBP), "image/webp");
+  assert.equal(detectSupportedImageMimeType(Buffer.from("hello world")), null);
+  assert.equal(detectSupportedImageMimeType(Buffer.from([0x00, 0x01, 0x02])), null);
+});
+
+test("looksLikeOpaqueBinary detects NUL bytes but not text or images", () => {
+  assert.equal(looksLikeOpaqueBinary(Buffer.from("plain text\n")), false);
+  assert.equal(looksLikeOpaqueBinary(MINI_PNG), false);
+  assert.equal(looksLikeOpaqueBinary(Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x00, 0x01])), true);
+});
+
+test("tryBuildImageReadResult returns image content for PNG with and without extension", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-hypa-img-"));
+  const withExt = join(dir, "pixel.png");
+  const noExt = join(dir, "pixel-noext");
+  await writeFile(withExt, MINI_PNG);
+  await writeFile(noExt, MINI_PNG);
+
+  for (const path of [withExt, noExt]) {
+    const result = await tryBuildImageReadResult(path);
+    assert.ok(result, `expected image result for ${path}`);
+    const types = result!.content.map((c) => c.type);
+    assert.deepEqual(types, ["text", "image"]);
+    const image = result!.content.find((c) => c.type === "image") as { type: "image"; data: string; mimeType: string };
+    assert.equal(image.mimeType, "image/png");
+    assert.ok(image.data.length > 0);
+    assert.equal(Buffer.from(image.data, "base64").compare(MINI_PNG), 0);
+    const text = result!.content.find((c) => c.type === "text") as { type: "text"; text: string };
+    assert.match(text.text, /image\/png/);
+    assert.doesNotMatch(text.text, /IHDR/);
+  }
+});
+
+test("tryBuildImageReadResult returns image content for jpeg/gif/webp", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-hypa-img-"));
+  const cases: Array<[string, Buffer, string]> = [
+    ["a.jpg", MINI_JPEG, "image/jpeg"],
+    ["a.gif", MINI_GIF, "image/gif"],
+    ["a.webp", MINI_WEBP, "image/webp"],
+  ];
+  for (const [name, bytes, mime] of cases) {
+    const path = join(dir, name);
+    await writeFile(path, bytes);
+    const result = await tryBuildImageReadResult(path);
+    assert.ok(result, `expected image for ${name}`);
+    const image = result!.content.find((c) => c.type === "image") as { mimeType: string; data: string };
+    assert.equal(image.mimeType, mime);
+    assert.ok(image.data.length > 0);
+  }
+});
+
+test("tryBuildImageReadResult notes non-vision models without dumping bytes as text", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-hypa-img-"));
+  const path = join(dir, "x.png");
+  await writeFile(path, MINI_PNG);
+  const result = await tryBuildImageReadResult(path, { model: { input: ["text"] } });
+  assert.ok(result);
+  const text = (result!.content.find((c) => c.type === "text") as { text: string }).text;
+  assert.match(text, /does not support images/i);
+  // Still include image part (host may strip); never mojibake the payload as text
+  assert.ok(result!.content.some((c) => c.type === "image"));
+});
+
+test("tryBuildImageReadResult returns binary notice for opaque non-image binary", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-hypa-bin-"));
+  const path = join(dir, "blob");
+  await writeFile(path, Buffer.from([0x00, 0x01, 0x02, 0xff, 0xfe]));
+  const result = await tryBuildImageReadResult(path);
+  assert.ok(result);
+  assert.equal(result!.content.length, 1);
+  assert.equal(result!.content[0].type, "text");
+  assert.match((result!.content[0] as { text: string }).text, /Binary file detected/i);
+});
+
+test("tryBuildImageReadResult returns null for ordinary text so cat path can run", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-hypa-txt-"));
+  const path = join(dir, "notes.txt");
+  await writeFile(path, "hello from hypa_read\n", "utf8");
+  const result = await tryBuildImageReadResult(path);
+  assert.equal(result, null);
 });

--- a/src/Hypa.Infrastructure/Mcp/McpToolResult.cs
+++ b/src/Hypa.Infrastructure/Mcp/McpToolResult.cs
@@ -31,6 +31,18 @@ internal static class McpToolResult
         Content = [new TextContentBlock { Text = text }]
     };
 
+    /// <summary>
+    /// Multimodal success: short text note plus an image content block for vision models.
+    /// </summary>
+    internal static CallToolResult OkWithImage(string text, byte[] imageBytes, string mimeType) => new()
+    {
+        Content =
+        [
+            new TextContentBlock { Text = text },
+            new ImageContentBlock { Data = imageBytes, MimeType = mimeType },
+        ]
+    };
+
     internal static CallToolResult Err(string message) => new()
     {
         IsError = true,

--- a/src/Hypa.Infrastructure/Mcp/Tools/HypaReadTool.cs
+++ b/src/Hypa.Infrastructure/Mcp/Tools/HypaReadTool.cs
@@ -17,8 +17,13 @@ public sealed class HypaReadTool
         [Description("Maximum tokens to return")] int? maxTokens = null)
     {
         var result = await fileReadService.ReadAsync(path, mode, maxTokens, cancellationToken);
-        return result.IsOk
-            ? McpToolResult.Ok(result.Value.Text)
-            : McpToolResult.Err($"SUMMARY\nError: {result.Error.Message}");
+        if (!result.IsOk)
+            return McpToolResult.Err($"SUMMARY\nError: {result.Error.Message}");
+
+        var output = result.Value;
+        if (output.IsImage && output.ImageBytes is not null && output.ImageMimeType is not null)
+            return McpToolResult.OkWithImage(output.Text, output.ImageBytes, output.ImageMimeType);
+
+        return McpToolResult.Ok(output.Text);
     }
 }

--- a/src/Hypa.Runtime/Application/Services/FileReadService.cs
+++ b/src/Hypa.Runtime/Application/Services/FileReadService.cs
@@ -15,6 +15,14 @@ public sealed record FileReadOutput
     public string Mode { get; init; } = string.Empty;
     public int Tokens { get; init; }
     public long DurationMs { get; init; }
+
+    /// <summary>When set, the read produced a vision image payload (not UTF-8 text).</summary>
+    public string? ImageMimeType { get; init; }
+
+    /// <summary>Raw image bytes when <see cref="ImageMimeType"/> is set; null for text reads.</summary>
+    public byte[]? ImageBytes { get; init; }
+
+    public bool IsImage => ImageMimeType is not null && ImageBytes is not null;
 }
 
 public sealed class FileReadService(
@@ -56,6 +64,49 @@ public sealed class FileReadService(
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             return Result<FileReadOutput, Error>.Fail(new Error("READ_ERROR", $"Error reading file: {ex.Message}"));
+        }
+
+        // Supported images: return vision payload instead of UTF-8 mojibake (issue #78).
+        var imageMime = ImageMimeSniffer.Detect(bytes);
+        if (imageMime is not null)
+        {
+            var imageText =
+                $"SUMMARY\nFile: {path}\n\nDETAILS\nRead image file [{imageMime}] ({FormatByteSize(bytes.Length)})\n\nSTATS\nmode=image duration={sw.ElapsedMilliseconds}ms";
+            var imageOutput = new FileReadOutput
+            {
+                Text = imageText,
+                Mode = "image",
+                Tokens = tokenCounter.EstimateTokens(imageText),
+                DurationMs = sw.ElapsedMilliseconds,
+                ImageMimeType = imageMime,
+                ImageBytes = bytes,
+            };
+
+            var imageArgs = CapabilityToolEvidence.BuildArgsJson(
+                ("path", path),
+                ("mode", mode ?? "smart"),
+                ("effectiveMode", "image"),
+                ("mimeType", imageMime),
+                ("maxTokens", maxTokens?.ToString()));
+            await CapabilityToolEvidence.RecordAsync(
+                evidenceLedger,
+                sessionResolver,
+                logger,
+                "hypa_read",
+                imageArgs,
+                imageText,
+                sw.ElapsedMilliseconds,
+                cancellationToken);
+
+            return Result<FileReadOutput, Error>.Ok(imageOutput);
+        }
+
+        if (ImageMimeSniffer.LooksLikeOpaqueBinary(bytes))
+        {
+            return Result<FileReadOutput, Error>.Fail(new Error(
+                "BINARY_FILE",
+                $"Binary file detected ({FormatByteSize(bytes.Length)}); not decoded as text. " +
+                "Supported image formats (png/jpeg/gif/webp) are returned as vision content when recognized by content sniffing."));
         }
 
         var content = Encoding.UTF8.GetString(bytes);
@@ -118,6 +169,14 @@ public sealed class FileReadService(
 
         return Result<FileReadOutput, Error>.Ok(output);
     }
+
+    private static string FormatByteSize(long bytes) =>
+        bytes switch
+        {
+            < 1024 => $"{bytes}B",
+            < 1024 * 1024 => $"{bytes / 1024}KB",
+            _ => $"{bytes / (1024.0 * 1024.0):0.0}MB",
+        };
 
     private string ResolveProjectRoot()
     {

--- a/src/Hypa.Runtime/Application/Services/FileReadService.cs
+++ b/src/Hypa.Runtime/Application/Services/FileReadService.cs
@@ -67,9 +67,19 @@ public sealed class FileReadService(
         }
 
         // Supported images: return vision payload instead of UTF-8 mojibake (issue #78).
+        // Cap inline attachment size to avoid multi-MB base64 payloads in MCP/context.
+        const int MaxInlineImageBytes = 5 * 1024 * 1024;
         var imageMime = ImageMimeSniffer.Detect(bytes);
         if (imageMime is not null)
         {
+            if (bytes.Length > MaxInlineImageBytes)
+            {
+                return Result<FileReadOutput, Error>.Fail(new Error(
+                    "IMAGE_TOO_LARGE",
+                    $"Image file [{imageMime}] is {FormatByteSize(bytes.Length)}; " +
+                    $"exceeds inline limit of {FormatByteSize(MaxInlineImageBytes)}. Use a smaller asset."));
+            }
+
             var imageText =
                 $"SUMMARY\nFile: {path}\n\nDETAILS\nRead image file [{imageMime}] ({FormatByteSize(bytes.Length)})\n\nSTATS\nmode=image duration={sw.ElapsedMilliseconds}ms";
             var imageOutput = new FileReadOutput

--- a/src/Hypa.Runtime/Domain/Common/ImageMimeSniffer.cs
+++ b/src/Hypa.Runtime/Domain/Common/ImageMimeSniffer.cs
@@ -1,0 +1,108 @@
+namespace Hypa.Runtime.Domain.Common;
+
+/// <summary>
+/// Magic-byte image MIME detection for hypa_read (parity with Pi coding-agent mime sniff).
+/// Detection is content-based — file extensions are never consulted.
+/// </summary>
+public static class ImageMimeSniffer
+{
+    private static readonly byte[] PngSignature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+    /// <summary>
+    /// Returns a supported raster MIME type (image/png|jpeg|gif|webp), or null when not recognized.
+    /// Animated PNG (acTL before IDAT) is rejected as unsupported for inline vision attachment.
+    /// </summary>
+    public static string? Detect(ReadOnlySpan<byte> buffer)
+    {
+        if (StartsWith(buffer, [0xff, 0xd8, 0xff]))
+        {
+            // JPEG-LS (0xF7) is not a standard vision attachment.
+            return buffer.Length > 3 && buffer[3] == 0xf7 ? null : "image/jpeg";
+        }
+
+        if (StartsWith(buffer, PngSignature))
+            return IsStaticPng(buffer) ? "image/png" : null;
+
+        if (StartsWithAscii(buffer, 0, "GIF87a") || StartsWithAscii(buffer, 0, "GIF89a"))
+            return "image/gif";
+
+        if (StartsWithAscii(buffer, 0, "RIFF") && StartsWithAscii(buffer, 8, "WEBP"))
+            return "image/webp";
+
+        return null;
+    }
+
+    /// <summary>
+    /// Heuristic: non-image buffers containing a NUL in the leading window are treated as opaque binary.
+    /// </summary>
+    public static bool LooksLikeOpaqueBinary(ReadOnlySpan<byte> buffer)
+    {
+        if (Detect(buffer) is not null)
+            return false;
+
+        var sampleLen = Math.Min(buffer.Length, 4100);
+        for (var i = 0; i < sampleLen; i++)
+        {
+            if (buffer[i] == 0)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsStaticPng(ReadOnlySpan<byte> buffer)
+    {
+        if (buffer.Length < 24)
+            return false;
+
+        // IHDR length must be 13 and type "IHDR"
+        if (ReadUInt32BE(buffer, PngSignature.Length) != 13)
+            return false;
+        if (!StartsWithAscii(buffer, 12, "IHDR"))
+            return false;
+
+        var offset = PngSignature.Length;
+        while (offset + 8 <= buffer.Length)
+        {
+            var chunkLength = (int)ReadUInt32BE(buffer, offset);
+            var typeOffset = offset + 4;
+            if (StartsWithAscii(buffer, typeOffset, "acTL"))
+                return false;
+            if (StartsWithAscii(buffer, typeOffset, "IDAT"))
+                return true;
+
+            var next = offset + 8 + chunkLength + 4;
+            if (next <= offset || next > buffer.Length)
+                return true; // incomplete sniff → allow
+            offset = next;
+        }
+
+        return true;
+    }
+
+    private static bool StartsWith(ReadOnlySpan<byte> buffer, ReadOnlySpan<byte> prefix)
+    {
+        if (buffer.Length < prefix.Length)
+            return false;
+        return buffer[..prefix.Length].SequenceEqual(prefix);
+    }
+
+    private static bool StartsWithAscii(ReadOnlySpan<byte> buffer, int offset, string text)
+    {
+        if (buffer.Length < offset + text.Length)
+            return false;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (buffer[offset + i] != (byte)text[i])
+                return false;
+        }
+
+        return true;
+    }
+
+    private static uint ReadUInt32BE(ReadOnlySpan<byte> buffer, int offset) =>
+        ((uint)buffer[offset] << 24) |
+        ((uint)buffer[offset + 1] << 16) |
+        ((uint)buffer[offset + 2] << 8) |
+        buffer[offset + 3];
+}

--- a/tests/Hypa.UnitTests/Application/CapabilityGapServiceTests.cs
+++ b/tests/Hypa.UnitTests/Application/CapabilityGapServiceTests.cs
@@ -75,6 +75,46 @@ public sealed class CapabilityGapServiceTests
             Arg.Any<CodeFileIdentity>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
+    // Minimal valid static PNG (1x1)
+    private static readonly byte[] MiniPng = Convert.FromHexString(
+        "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c63000100000500010d0a2db40000000049454e44ae426082");
+
+    [Fact]
+    public async Task FileReadAsync_WhenPngByMagicBytes_ReturnsImagePayloadNotUtf8Dump()
+    {
+        var service = MakeFileReadService(out var fileSystem, out _, out _);
+        // Extensionless path — detection must use magic bytes, not extension.
+        var imagePath = ProjectPath("assets", "pixel-noext");
+        fileSystem.FileExists(imagePath).Returns(true);
+        fileSystem.ReadAllBytes(imagePath).Returns(MiniPng);
+
+        var result = await service.ReadAsync("assets/pixel-noext", mode: "full", maxTokens: null, CancellationToken.None);
+
+        Assert.True(result.IsOk);
+        Assert.True(result.Value.IsImage);
+        Assert.Equal("image/png", result.Value.ImageMimeType);
+        Assert.NotNull(result.Value.ImageBytes);
+        Assert.Equal(MiniPng, result.Value.ImageBytes);
+        Assert.Contains("image/png", result.Value.Text);
+        Assert.DoesNotContain("IHDR", result.Value.Text);
+        Assert.Equal("image", result.Value.Mode);
+    }
+
+    [Fact]
+    public async Task FileReadAsync_WhenOpaqueBinary_ReturnsBinaryFileError()
+    {
+        var service = MakeFileReadService(out var fileSystem, out _, out _);
+        var binPath = ProjectPath("assets", "blob.bin");
+        fileSystem.FileExists(binPath).Returns(true);
+        fileSystem.ReadAllBytes(binPath).Returns(new byte[] { 0x00, 0x01, 0x02, 0xff, 0xfe });
+
+        var result = await service.ReadAsync("assets/blob.bin", mode: "full", maxTokens: null, CancellationToken.None);
+
+        Assert.False(result.IsOk);
+        Assert.Equal("BINARY_FILE", result.Error.Code);
+        Assert.Contains("Binary file detected", result.Error.Message);
+    }
+
     [Fact]
     public async Task CompressAsync_WithNoMatchingCompressor_ReturnsPassthroughAndRecordsEvidence()
     {

--- a/tests/Hypa.UnitTests/Domain/ImageMimeSnifferTests.cs
+++ b/tests/Hypa.UnitTests/Domain/ImageMimeSnifferTests.cs
@@ -1,0 +1,49 @@
+using Hypa.Runtime.Domain.Common;
+using Xunit;
+
+namespace Hypa.UnitTests.Domain;
+
+public sealed class ImageMimeSnifferTests
+{
+    // Minimal valid static PNG (1x1) with IHDR + IDAT + IEND
+    private static readonly byte[] MiniPng = Convert.FromHexString(
+        "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c63000100000500010d0a2db40000000049454e44ae426082");
+
+    private static readonly byte[] MiniJpeg =
+        [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0xff, 0xd9];
+
+    private static readonly byte[] MiniGif =
+        "GIF89a\x01\x00\x01\x00\x00\x00\x00;"u8.ToArray();
+
+    private static readonly byte[] MiniWebp =
+    [
+        (byte)'R', (byte)'I', (byte)'F', (byte)'F',
+        0x0a, 0x00, 0x00, 0x00,
+        (byte)'W', (byte)'E', (byte)'B', (byte)'P',
+        (byte)'X', (byte)'X', (byte)'X', (byte)'X',
+    ];
+
+    [Fact]
+    public void Detect_RecognizesPngJpegGifWebp()
+    {
+        Assert.Equal("image/png", ImageMimeSniffer.Detect(MiniPng));
+        Assert.Equal("image/jpeg", ImageMimeSniffer.Detect(MiniJpeg));
+        Assert.Equal("image/gif", ImageMimeSniffer.Detect(MiniGif));
+        Assert.Equal("image/webp", ImageMimeSniffer.Detect(MiniWebp));
+    }
+
+    [Fact]
+    public void Detect_ReturnsNullForTextAndOpaqueBinary()
+    {
+        Assert.Null(ImageMimeSniffer.Detect("hello world"u8));
+        Assert.Null(ImageMimeSniffer.Detect([0x00, 0x01, 0x02, 0xff]));
+    }
+
+    [Fact]
+    public void LooksLikeOpaqueBinary_DetectsNulButNotTextOrImages()
+    {
+        Assert.False(ImageMimeSniffer.LooksLikeOpaqueBinary("plain text\n"u8));
+        Assert.False(ImageMimeSniffer.LooksLikeOpaqueBinary(MiniPng));
+        Assert.True(ImageMimeSniffer.LooksLikeOpaqueBinary([0x7f, 0x45, 0x4c, 0x46, 0x00, 0x01]));
+    }
+}

--- a/tests/Hypa.UnitTests/Infrastructure/Mcp/HypaReadToolTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Mcp/HypaReadToolTests.cs
@@ -120,4 +120,50 @@ public sealed class HypaReadToolTests : IDisposable
             Assert.Fail($"Expected no exception, but got: {ex}");
         }
     }
+
+    // Minimal valid static PNG (1x1)
+    private static readonly byte[] MiniPng = Convert.FromHexString(
+        "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c63000100000500010d0a2db40000000049454e44ae426082");
+
+    [Fact]
+    public async Task ImageFile_ReturnsImageContentBlock_NotUtf8Dump()
+    {
+        var tmpFile = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"hypa-img-{Guid.NewGuid():N}");
+        _tempFiles.Add(tmpFile);
+        System.IO.File.WriteAllBytes(tmpFile, MiniPng);
+        _rootDetector.Detect(Arg.Any<string>()).Returns(System.IO.Path.GetDirectoryName(tmpFile)!);
+        _fileSystem.FileExists(tmpFile).Returns(true);
+        _fileSystem.ReadAllBytes(tmpFile).Returns(MiniPng);
+
+        var result = await HypaReadTool.ExecuteAsync(
+            MakeService(), CancellationToken.None, tmpFile, "full");
+
+        Assert.True(result.IsError is not true);
+        Assert.Contains(result.Content, c => c is TextContentBlock);
+        var image = Assert.IsType<ImageContentBlock>(
+            result.Content.FirstOrDefault(c => c is ImageContentBlock));
+        Assert.Equal("image/png", image.MimeType);
+        Assert.True(image.Data.Length > 0);
+        Assert.Equal(MiniPng, image.Data.ToArray());
+        Assert.DoesNotContain("IHDR", TextOf(result));
+    }
+
+    [Fact]
+    public async Task OpaqueBinary_ReturnsError_NotUtf8Dump()
+    {
+        var tmpFile = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"hypa-bin-{Guid.NewGuid():N}");
+        _tempFiles.Add(tmpFile);
+        var blob = new byte[] { 0x00, 0x01, 0x02, 0xff };
+        System.IO.File.WriteAllBytes(tmpFile, blob);
+        _rootDetector.Detect(Arg.Any<string>()).Returns(System.IO.Path.GetDirectoryName(tmpFile)!);
+        _fileSystem.FileExists(tmpFile).Returns(true);
+        _fileSystem.ReadAllBytes(tmpFile).Returns(blob);
+
+        var result = await HypaReadTool.ExecuteAsync(
+            MakeService(), CancellationToken.None, tmpFile, "full");
+
+        Assert.True(result.IsError);
+        Assert.Contains("Binary file detected", TextOf(result));
+        Assert.DoesNotContain(result.Content, c => c is ImageContentBlock);
+    }
 }


### PR DESCRIPTION
## Summary

`hypa_read` no longer dumps PNG/JPEG/GIF/WEBP bytes as UTF-8 text (mojibake). Supported images are detected by **magic bytes** (not extension) and returned as vision-friendly multimodal content:

- **pi-hypa `hypa_read`**: text note + `{ type: "image", data, mimeType }` content part (critical in replace mode where Pi’s builtin `read` is disabled).
- **MCP `hypa_read` / `FileReadService`**: `TextContentBlock` + `ImageContentBlock` for the same formats.
- Opaque non-image binaries get a clear binary notice / `BINARY_FILE` error instead of garbage text.
- Ordinary text reads keep the existing Hypa CLI truncation / offset-limit path.

Also avoids loading entire text files just to sniff: only the leading 4100-byte window is read unless an image is confirmed. Inline image payloads are capped at 5MB.

## Test plan

- [x] `npx tsx --test test/tools.test.ts` in `packages/pi-hypa` (sniff + image content shape + binary notice + text fall-through)
- [x] `tsc --noEmit` for pi-hypa
- [x] `dotnet test tests/Hypa.UnitTests` filtered to ImageMimeSniffer / HypaReadTool / FileReadAsync (15 passed)
- [x] Broader unit filter Application + Infrastructure.Mcp + Domain (593 passed earlier in session)

## Codex review

- Model: **gpt-5.6-luna**, reasoning effort **xhigh**, sandbox read-only
- Full `codex exec review --base main` timed out at 600s before final write; partial session flagged full-file probe on text reads
- Follow-up commit fixed that and added MCP 5MB image cap
- **Verdict:** `pass_after_fix` (0 open bug-severity items)

Closes #78
