### PR TITLE
Fix hypa -c bypassing shell for globs and brace expansion

### DIFF
--- a/src/Hypa.Cli/Commands/RunCommand.cs
+++ b/src/Hypa.Cli/Commands/RunCommand.cs
@@ -87,6 +87,7 @@ public sealed class RunCommand(CommandRunnerService runnerService, IShellLexer s
             lexed.Any(t => t.Kind is TokenKind.Operator or TokenKind.Pipe or TokenKind.Redirect or TokenKind.Shellism)
             || ShellExpansion.ContainsExpansion(lexed)
             || ShellExpansion.ContainsTildeExpansion(lexed)
+            || ShellExpansion.ContainsGlobOrBraceExpansion(lexed)
             || ShellVerb.HasAssignmentPrefix(lexed)
             || (verb is not null && ShellBuiltins.IsStateful(verb));
 

--- a/src/Hypa.Infrastructure/Mcp/Tools/HypaShellTool.cs
+++ b/src/Hypa.Infrastructure/Mcp/Tools/HypaShellTool.cs
@@ -88,7 +88,8 @@ public sealed class HypaShellTool
             var usesShellSyntax =
                 lexed.Any(t => t.Kind is TokenKind.Operator or TokenKind.Pipe or TokenKind.Redirect or TokenKind.Shellism)
                 || ShellExpansion.ContainsExpansion(lexed)
-                || ShellExpansion.ContainsTildeExpansion(lexed);
+                || ShellExpansion.ContainsTildeExpansion(lexed)
+                || ShellExpansion.ContainsGlobOrBraceExpansion(lexed);
 
             var timeout = TimeSpan.FromMilliseconds(timeoutMs ?? 120_000);
             CommandInvocation invocation;

--- a/src/Hypa.Runtime/Domain/Rewrite/ShellExpansion.cs
+++ b/src/Hypa.Runtime/Domain/Rewrite/ShellExpansion.cs
@@ -38,9 +38,11 @@ public static class ShellExpansion
     /// <list type="bullet">
     /// <item>Glob: any unquoted <c>*</c>, <c>?</c>, or <c>[</c> in an Arg token.</item>
     /// <item>
-    /// Brace: an unquoted <c>{…}</c> whose interior contains <c>,</c> or
-    /// <c>..</c> (forms a shell would actually brace-expand). Bare pairs such
-    /// as <c>{x}</c> are left on the direct path.
+    /// Brace: an unquoted <c>{…}</c> (or an open <c>{</c> prefix split across
+    /// quote boundaries) whose interior contains <c>,</c> or <c>..</c>.
+    /// Bare pairs such as <c>{x}</c> stay on the direct path. Detection is
+    /// intentionally broad for ranges (any <c>..</c>); false-positive shell
+    /// routing is preferred over missing real expansions.
     /// </item>
     /// </list>
     /// Quoted tokens (<see cref="TokenKind.QuotedArg"/>) are never treated as
@@ -89,8 +91,15 @@ public static class ShellExpansion
         value.Contains('*') || value.Contains('?') || value.Contains('[');
 
     /// <summary>
-    /// Conservative brace-expansion detection: any <c>{…}</c> span whose
-    /// interior contains a comma or <c>..</c> range marker.
+    /// Conservative brace-expansion detection: any <c>{…}</c> span (or an
+    /// open <c>{</c> that continues past the end of this token) whose interior
+    /// contains a comma or <c>..</c> range marker.
+    /// <para>
+    /// Open spans matter because the lexer splits on quotes, so a single shell
+    /// word such as <c>{a,"b"}</c> becomes adjacent Arg/QuotedArg tokens
+    /// (<c>{a,</c> then <c>"b"</c> then <c>}</c>). Detecting the incomplete
+    /// prefix still forces shell routing so the whole word expands correctly.
+    /// </para>
     /// </summary>
     private static bool HasBraceExpansionForm(string value)
     {
@@ -100,12 +109,15 @@ public static class ShellExpansion
                 continue;
 
             var close = value.IndexOf('}', i + 1);
-            if (close < 0)
-                break;
-
-            var content = value.AsSpan(i + 1, close - i - 1);
+            // No closing brace in this token: still inspect the remainder so
+            // quote-split prefixes like "{a," route through the shell.
+            var end = close < 0 ? value.Length : close;
+            var content = value.AsSpan(i + 1, end - i - 1);
             if (content.Contains(',') || content.Contains("..", StringComparison.Ordinal))
                 return true;
+
+            if (close < 0)
+                break;
 
             i = close;
         }

--- a/src/Hypa.Runtime/Domain/Rewrite/ShellExpansion.cs
+++ b/src/Hypa.Runtime/Domain/Rewrite/ShellExpansion.cs
@@ -1,9 +1,11 @@
 namespace Hypa.Runtime.Domain.Rewrite;
 
-/// Detects command-substitution, variable-expansion, and tilde-expansion markers
-/// embedded inside argument tokens. Such tokens must be routed through
-/// `sh -c` so the shell performs the expansion; running the program directly
-/// would pass the unexpanded text through as a literal argument.
+/// <summary>
+/// Detects expansion markers embedded inside argument tokens that require the
+/// platform shell (<c>sh -c</c> / <c>cmd.exe /c</c>) so expansion happens before
+/// the program runs. Running the program directly would pass the unexpanded
+/// text through as a literal argument.
+/// </summary>
 public static class ShellExpansion
 {
     public static bool ContainsExpansion(IReadOnlyList<ShellToken> tokens) =>
@@ -18,16 +20,36 @@ public static class ShellExpansion
     /// the program directly would pass the literal text through as an argument,
     /// so such commands must route through <c>sh -c</c>.
     /// <para>
-    /// Quoted tildes (<c>"~/x"</c>), non-leading tildes (<c>a~b</c>), and
-    /// non-POSIX forms such as <c>~*</c> / <c>~?</c> are intentionally left on
-    /// the direct-execution path: the shell would not perform tilde expansion
-    /// for them, and routing would only change globbing semantics.
+    /// Quoted tildes (<c>"~/x"</c>) and non-leading tildes (<c>a~b</c>) are not
+    /// tilde words. Forms such as <c>~*</c> / <c>~?</c> are also not tilde words
+    /// (login names cannot contain glob metacharacters); they may still route
+    /// through the shell via <see cref="ContainsGlobOrBraceExpansion"/> for
+    /// pathname expansion.
     /// </para>
     /// </summary>
     public static bool ContainsTildeExpansion(IReadOnlyList<ShellToken> tokens) =>
         tokens.Any(token =>
             token.Kind is TokenKind.Arg &&
             IsTildeWord(token.Value));
+
+    /// <summary>
+    /// Detects unquoted argument tokens that require the shell for pathname
+    /// expansion (glob) or brace expansion.
+    /// <list type="bullet">
+    /// <item>Glob: any unquoted <c>*</c>, <c>?</c>, or <c>[</c> in an Arg token.</item>
+    /// <item>
+    /// Brace: an unquoted <c>{…}</c> whose interior contains <c>,</c> or
+    /// <c>..</c> (forms a shell would actually brace-expand). Bare pairs such
+    /// as <c>{x}</c> are left on the direct path.
+    /// </item>
+    /// </list>
+    /// Quoted tokens (<see cref="TokenKind.QuotedArg"/>) are never treated as
+    /// expanding for glob or brace, matching shell quoting rules.
+    /// </summary>
+    public static bool ContainsGlobOrBraceExpansion(IReadOnlyList<ShellToken> tokens) =>
+        tokens.Any(token =>
+            token.Kind is TokenKind.Arg &&
+            (HasGlobMetacharacter(token.Value) || HasBraceExpansionForm(token.Value)));
 
     /// <summary>
     /// Returns true for words a POSIX shell would treat as candidates for tilde
@@ -47,8 +69,7 @@ public static class ShellExpansion
             return true;
 
         // ~user or ~user/... — login name must be non-empty and free of
-        // metacharacters such as * ? [ that would otherwise force shell routing
-        // solely for globbing side effects.
+        // metacharacters such as * ? [ (those are glob forms, not tilde words).
         var slash = value.IndexOf('/', 1);
         var loginLength = slash < 0 ? value.Length - 1 : slash - 1;
         if (loginLength <= 0)
@@ -62,5 +83,33 @@ public static class ShellExpansion
         }
 
         return true;
+    }
+
+    private static bool HasGlobMetacharacter(string value) =>
+        value.Contains('*') || value.Contains('?') || value.Contains('[');
+
+    /// <summary>
+    /// Conservative brace-expansion detection: any <c>{…}</c> span whose
+    /// interior contains a comma or <c>..</c> range marker.
+    /// </summary>
+    private static bool HasBraceExpansionForm(string value)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] != '{')
+                continue;
+
+            var close = value.IndexOf('}', i + 1);
+            if (close < 0)
+                break;
+
+            var content = value.AsSpan(i + 1, close - i - 1);
+            if (content.Contains(',') || content.Contains("..", StringComparison.Ordinal))
+                return true;
+
+            i = close;
+        }
+
+        return false;
     }
 }

--- a/tests/Hypa.UnitTests/Cli/RunCommandTests.cs
+++ b/tests/Hypa.UnitTests/Cli/RunCommandTests.cs
@@ -300,6 +300,7 @@ public sealed class RunCommandTests
     [InlineData("ls file[ab].txt")]
     [InlineData("echo {a,b}")]
     [InlineData("echo {1..3}")]
+    [InlineData("echo {a,\"b\"}")]
     public async Task BufferedGlobOrBraceCommand_UsesShellInvocation(string command)
     {
         var (root, runner) = BuildRoot();

--- a/tests/Hypa.UnitTests/Cli/RunCommandTests.cs
+++ b/tests/Hypa.UnitTests/Cli/RunCommandTests.cs
@@ -275,12 +275,53 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public async Task BufferedTildeGlobPattern_UsesDirectInvocation()
+    public async Task BufferedTildeGlobPattern_UsesShellInvocation()
     {
-        // ~* / ~? are not POSIX tilde words; routing them through the shell
-        // would only enable globbing side effects without performing tilde
-        // expansion. Keep the direct-execution path.
+        // ~* is not a POSIX tilde word, but the unquoted * requires pathname
+        // expansion, so the shell path is intentional.
         var command = "echo ~*";
+        var (root, runner) = BuildRoot();
+        CommandInvocation? invocation = null;
+        runner.RunAsync(Arg.Do<CommandInvocation>(i => invocation = i), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("ok", "", 0, TimeSpan.Zero)));
+
+        var exitCode = await root.InvokeAsync(["-c", command]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(invocation);
+        Assert.Equal(ExpectedShell, invocation.Executable);
+        Assert.Equal(ExpectedShellArgs(command), invocation.Arguments);
+    }
+
+    [Theory]
+    [InlineData("ls path/*.json")]
+    [InlineData("echo file?")]
+    [InlineData("ls file[ab].txt")]
+    [InlineData("echo {a,b}")]
+    [InlineData("echo {1..3}")]
+    public async Task BufferedGlobOrBraceCommand_UsesShellInvocation(string command)
+    {
+        var (root, runner) = BuildRoot();
+        CommandInvocation? invocation = null;
+        runner.RunAsync(Arg.Do<CommandInvocation>(i => invocation = i), Arg.Any<CancellationToken>())
+            .Returns(Result<CommandOutput, Error>.Ok(
+                CommandOutput.Captured("ok", "", 0, TimeSpan.Zero)));
+
+        var exitCode = await root.InvokeAsync(["-c", command]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(invocation);
+        Assert.Equal(ExpectedShell, invocation.Executable);
+        Assert.Equal(ExpectedShellArgs(command), invocation.Arguments);
+    }
+
+    [Theory]
+    [InlineData("echo \"*.ts\"")]
+    [InlineData("echo '{a,b}'")]
+    [InlineData("echo {x}")]
+    public async Task BufferedQuotedOrNonExpandingGlobBrace_UsesDirectInvocation(string command)
+    {
         var (root, runner) = BuildRoot();
         CommandInvocation? invocation = null;
         runner.RunAsync(Arg.Do<CommandInvocation>(i => invocation = i), Arg.Any<CancellationToken>())

--- a/tests/Hypa.UnitTests/Domain/ShellExpansionTests.cs
+++ b/tests/Hypa.UnitTests/Domain/ShellExpansionTests.cs
@@ -164,14 +164,94 @@ public sealed class ShellExpansionTests
     [InlineData("~user?x")]
     public void ContainsTildeExpansion_GlobLikeTildeForms_ReturnFalse(string value)
     {
-        // Copilot review on #65: ~* / ~? start with ~ but are not POSIX tilde
-        // words. Routing them through the shell would enable globbing without
-        // performing tilde expansion.
+        // ~* / ~? start with ~ but are not POSIX tilde words (login names
+        // cannot contain glob metacharacters). They still route via
+        // ContainsGlobOrBraceExpansion for pathname expansion.
         var tokens = new[]
         {
             new ShellToken(TokenKind.Arg, value, 0),
         };
 
         Assert.False(ShellExpansion.ContainsTildeExpansion(tokens));
+    }
+
+    [Theory]
+    [InlineData("*.json")]
+    [InlineData("path/*.ts")]
+    [InlineData("file?")]
+    [InlineData("file[ab]")]
+    [InlineData("~*")]
+    [InlineData("~?")]
+    [InlineData("~[a]")]
+    public void ContainsGlobOrBraceExpansion_UnquotedGlob_ReturnsTrue(string value)
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, value, 0),
+        };
+
+        Assert.True(ShellExpansion.ContainsGlobOrBraceExpansion(tokens));
+    }
+
+    [Theory]
+    [InlineData("{a,b}")]
+    [InlineData("file{a,b}.txt")]
+    [InlineData("{1..3}")]
+    [InlineData("pre{x..y}post")]
+    [InlineData("{a,b,c}")]
+    public void ContainsGlobOrBraceExpansion_UnquotedBrace_ReturnsTrue(string value)
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, value, 0),
+        };
+
+        Assert.True(ShellExpansion.ContainsGlobOrBraceExpansion(tokens));
+    }
+
+    [Theory]
+    [InlineData("plain")]
+    [InlineData("{x}")]
+    [InlineData("{}")]
+    [InlineData("a{b}c")]
+    [InlineData("no-braces")]
+    public void ContainsGlobOrBraceExpansion_PlainOrNonExpandingBrace_ReturnsFalse(string value)
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, value, 0),
+        };
+
+        Assert.False(ShellExpansion.ContainsGlobOrBraceExpansion(tokens));
+    }
+
+    [Theory]
+    [InlineData("\"*.ts\"")]
+    [InlineData("'*.json'")]
+    [InlineData("\"{a,b}\"")]
+    [InlineData("'{1..3}'")]
+    [InlineData("\"file?\"")]
+    public void ContainsGlobOrBraceExpansion_QuotedGlobOrBrace_ReturnsFalse(string value)
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.QuotedArg, value, 0),
+        };
+
+        Assert.False(ShellExpansion.ContainsGlobOrBraceExpansion(tokens));
+    }
+
+    [Fact]
+    public void ContainsGlobOrBraceExpansion_OnlyScansArgTokens()
+    {
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Operator, "&&", 0),
+            new ShellToken(TokenKind.Pipe, "|", 3),
+            new ShellToken(TokenKind.QuotedArg, "\"*.ts\"", 5),
+            new ShellToken(TokenKind.Arg, "plain", 12),
+        };
+
+        Assert.False(ShellExpansion.ContainsGlobOrBraceExpansion(tokens));
     }
 }

--- a/tests/Hypa.UnitTests/Domain/ShellExpansionTests.cs
+++ b/tests/Hypa.UnitTests/Domain/ShellExpansionTests.cs
@@ -199,11 +199,26 @@ public sealed class ShellExpansionTests
     [InlineData("{1..3}")]
     [InlineData("pre{x..y}post")]
     [InlineData("{a,b,c}")]
+    [InlineData("{a,")] // quote-split prefix of {a,"b"}
     public void ContainsGlobOrBraceExpansion_UnquotedBrace_ReturnsTrue(string value)
     {
         var tokens = new[]
         {
             new ShellToken(TokenKind.Arg, value, 0),
+        };
+
+        Assert.True(ShellExpansion.ContainsGlobOrBraceExpansion(tokens));
+    }
+
+    [Fact]
+    public void ContainsGlobOrBraceExpansion_QuoteSplitBraceWord_ReturnsTrue()
+    {
+        // Lexer yields Arg("{a,") + QuotedArg("\"b\"") + Arg("}") for {a,"b"}.
+        var tokens = new[]
+        {
+            new ShellToken(TokenKind.Arg, "{a,", 0),
+            new ShellToken(TokenKind.QuotedArg, "\"b\"", 3),
+            new ShellToken(TokenKind.Arg, "}", 6),
         };
 
         Assert.True(ShellExpansion.ContainsGlobOrBraceExpansion(tokens));

--- a/tests/Hypa.UnitTests/Infrastructure/Mcp/HypaShellToolTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Mcp/HypaShellToolTests.cs
@@ -170,6 +170,7 @@ public sealed class HypaShellToolTests
     [InlineData("echo {a,b}")]
     [InlineData("echo {1..3}")]
     [InlineData("echo ~*")]
+    [InlineData("echo {a,\"b\"}")]
     public async Task HypaShell_ExpansionCommand_UsesShellInterpreter(string command)
     {
         CommandInvocation? captured = null;

--- a/tests/Hypa.UnitTests/Infrastructure/Mcp/HypaShellToolTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/Mcp/HypaShellToolTests.cs
@@ -164,6 +164,12 @@ public sealed class HypaShellToolTests
     [InlineData("echo ~")]
     [InlineData("echo ~user/bin")]
     [InlineData("echo \"$HOME\"")]
+    [InlineData("ls path/*.json")]
+    [InlineData("echo file?")]
+    [InlineData("ls file[ab].txt")]
+    [InlineData("echo {a,b}")]
+    [InlineData("echo {1..3}")]
+    [InlineData("echo ~*")]
     public async Task HypaShell_ExpansionCommand_UsesShellInterpreter(string command)
     {
         CommandInvocation? captured = null;
@@ -197,8 +203,10 @@ public sealed class HypaShellToolTests
     [Theory]
     [InlineData("echo \"~/Desktop\"")]
     [InlineData("echo a~b")]
-    [InlineData("echo ~*")]
-    public async Task HypaShell_NonExpandingTilde_UsesDirectProcessInvocation(string command)
+    [InlineData("echo \"*.ts\"")]
+    [InlineData("echo '{a,b}'")]
+    [InlineData("echo {x}")]
+    public async Task HypaShell_NonExpandingTildeOrQuotedGlob_UsesDirectProcessInvocation(string command)
     {
         CommandInvocation? captured = null;
         var compressedRunner = Substitute.For<ICommandRunnerService>();


### PR DESCRIPTION
## Summary

`hypa -c` and MCP `hypa_shell` buffered execution only routed shell operators, `$`/backticks, and POSIX tilde words through the platform shell. Unquoted globs (`*`, `?`, `[…]`) and brace forms (`{a,b}`, `{1..3}`) took the direct process-spawn path, so patterns were passed literally (e.g. `ls path/*.json` saw a nonexistent path named `*.json`).

This fix adds `ShellExpansion.ContainsGlobOrBraceExpansion` and ORs it into the same routing used by CLI and MCP:

- **Glob:** unquoted `*`, `?`, or `[` in an `Arg` token → shell
- **Brace:** unquoted `{…}` whose interior contains `,` or `..` → shell
- **Quote-split braces:** open prefixes like `{a,` (from `{a,"b"}`) still force shell routing
- **Quoted patterns** (`"*.ts"`, `'{a,b}'`) and non-expanding `{x}` stay on the direct path
- **`~*` / `~?`:** still not tilde words, but now shell-route via glob detection

Platform wrappers are unchanged (`sh -c` / `cmd.exe /d /s /c`), matching the #71 approach. Perfect Windows/`dash` brace parity is intentionally out of scope.

## Test plan

- [x] `dotnet test tests/Hypa.UnitTests --filter "FullyQualifiedName~ShellExpansion|FullyQualifiedName~RunCommandTests|FullyQualifiedName~HypaShellTool"` → **115 passed**
- [x] Detector unit tests for `* ? [`, braces, quoted forms, `{x}`, `~*`, quote-split `{a,"b"}`
- [x] CLI + MCP routing tests for shell vs direct paths
- [x] Manual: `hypa -c 'printf "%s\n" {a,"b"}'` expands to `a` / `b` on this host

## Codex review (gpt-5.6-luna, xhigh)

- Initial review: **fail** with 2 bugs + 2 suggestions
- **Bug 1 (fixed):** quote-split brace words like `{a,"b"}` missed → fixed open-prefix detection + tests
- **Bug 2 (wontfix / out of scope):** `dash` lacks brace expansion; `cmd.exe` lacks general pathname expansion — issue brief explicitly reuses existing shell wrappers and lists perfect Windows brace parity as out of scope (same class as #71)
- **Suggestions:** doc tightened for broad `..` matching; mixed-quote test added
- **Verdict after fix:** `pass_after_fix` · open bug-severity items: **0**

Closes #81
