### PR TITLE
Fix rewrite passthrough for agent commands with cd pipes and redirects

### DIFF
--- a/src/Hypa.Infrastructure/Rewrite/CommandRewriteRegistry.cs
+++ b/src/Hypa.Infrastructure/Rewrite/CommandRewriteRegistry.cs
@@ -44,6 +44,12 @@ public sealed class CommandRewriteRegistry(
     private RewriteDecision RewriteSegment(
         IReadOnlyList<ShellToken> tokens, RewriteContext context)
     {
+        // Any stdout/stdin redirect anywhere in the segment (including pipe consumers)
+        // can make compressed producer output land in a file or change read intent.
+        // Only stderr merge (2>&1) is treated as safe plumbing.
+        if (HasUnsafeRedirect(tokens))
+            return RewriteDecision.Passthrough();
+
         // Split at the first pipe: rewrite producer only; leave consumer raw.
         if (!TrySplitAtFirstPipe(tokens, out var producerTokens, out var pipeSuffix))
             return RewriteDecision.Passthrough();
@@ -123,6 +129,10 @@ public sealed class CommandRewriteRegistry(
             if (decision.Outcome == RewriteOutcome.Deny)
                 return RewriteDecision.Deny();
 
+            // Preserve Ask so compound approval is not silently auto-allowed.
+            if (decision.Outcome == RewriteOutcome.Ask)
+                return decision;
+
             if (decision.Outcome != RewriteOutcome.Passthrough)
                 anyRewritten = true;
 
@@ -135,6 +145,13 @@ public sealed class CommandRewriteRegistry(
         var joined = string.Join(" ", parts);
         return RewriteDecision.Rewritten(joined);
     }
+
+    /// <summary>
+    /// True when the segment contains a redirect other than stderr merge (<c>2>&1</c>).
+    /// Covers producer and pipe-consumer sides so write redirects force passthrough.
+    /// </summary>
+    private static bool HasUnsafeRedirect(IReadOnlyList<ShellToken> tokens) =>
+        tokens.Any(t => t.Kind == TokenKind.Redirect && t.Value != "2>&1");
 
     /// <summary>
     /// Split tokens at the first pipe. <paramref name="pipeSuffix"/> includes leading

--- a/src/Hypa.Infrastructure/Rewrite/CommandRewriteRegistry.cs
+++ b/src/Hypa.Infrastructure/Rewrite/CommandRewriteRegistry.cs
@@ -23,15 +23,14 @@ public sealed class CommandRewriteRegistry(
         // Split on compound operators and rewrite each segment
         var segments = SplitOnOperators(tokens);
 
-        // A builtin that mutates shell state or a shell reserved word can't
-        // survive being split into separate `hypa -c` processes. If any segment
-        // starts with one, pass the whole command through unchanged to preserve
-        // exact shell semantics.
+        // Shell reserved words / control constructs require intact grammar
+        // (loops, conditionals, brace groups). Stateful builtins do not —
+        // they are left raw at segment level while rewritable siblings rewrite.
         if (segments.Any(SegmentRequiresWholeShell))
             return RewriteDecision.Passthrough();
 
         if (segments.Count == 1)
-            return RewriteSegment(segments[0].Tokens, command, context);
+            return RewriteSegment(segments[0].Tokens, context);
 
         return RewriteCompound(segments, context);
     }
@@ -39,30 +38,67 @@ public sealed class CommandRewriteRegistry(
     private static bool SegmentRequiresWholeShell(Segment segment)
     {
         var verb = ShellVerb.Extract(segment.Tokens);
-        return verb is not null && (ShellBuiltins.IsStateful(verb) || ShellReservedWords.IsReservedWord(verb));
+        return verb is not null && ShellReservedWords.IsReservedWord(verb);
     }
 
     private RewriteDecision RewriteSegment(
-        IReadOnlyList<ShellToken> tokens, string originalCommand, RewriteContext context)
+        IReadOnlyList<ShellToken> tokens, RewriteContext context)
     {
-        // Pipe or redirect: passthrough to preserve shell plumbing intact
-        if (tokens.Any(t => t.Kind is TokenKind.Pipe or TokenKind.Redirect))
+        // Split at the first pipe: rewrite producer only; leave consumer raw.
+        if (!TrySplitAtFirstPipe(tokens, out var producerTokens, out var pipeSuffix))
             return RewriteDecision.Passthrough();
 
-        var verb = tokens.FirstOrDefault(t => t.Kind == TokenKind.Arg)?.Value;
+        // Peel trailing safe redirects (e.g. 2>&1) off the producer; re-append later.
+        if (!TrySplitTrailingRedirects(producerTokens, out var coreTokens, out var redirectSuffix, out var redirectsSafe))
+            return RewriteDecision.Passthrough();
+
+        if (!redirectsSafe)
+            return RewriteDecision.Passthrough();
+
+        // Pipes: only first-class strategies — generic compression can break consumers
+        // that expect native producer format (grep, path listers, etc.).
+        var allowGenericWrapper = pipeSuffix is null;
+        var coreDecision = RewriteSimpleCommand(coreTokens, context, allowGenericWrapper);
+
+        if (coreDecision.Outcome is RewriteOutcome.Deny or RewriteOutcome.Ask)
+            return coreDecision;
+
+        if (coreDecision.Outcome == RewriteOutcome.Passthrough || coreDecision.Command is null)
+            return RewriteDecision.Passthrough();
+
+        var reassembled = coreDecision.Command
+            + (redirectSuffix ?? string.Empty)
+            + (pipeSuffix ?? string.Empty);
+
+        return coreDecision.Outcome == RewriteOutcome.GenericWrapper
+            ? RewriteDecision.Generic(reassembled)
+            : RewriteDecision.Rewritten(reassembled);
+    }
+
+    private RewriteDecision RewriteSimpleCommand(
+        IReadOnlyList<ShellToken> tokens,
+        RewriteContext context,
+        bool allowGenericWrapper)
+    {
+        var verb = ShellVerb.Extract(tokens);
         if (verb is null)
+            return RewriteDecision.Passthrough();
+
+        // Stateful builtins (cd/export/…) must never be wrapped — they mutate shell state.
+        if (ShellBuiltins.IsStateful(verb) || ShellReservedWords.IsReservedWord(verb))
             return RewriteDecision.Passthrough();
 
         if (context.ExcludeCommands.Contains(verb, StringComparer.OrdinalIgnoreCase))
             return RewriteDecision.Passthrough();
 
+        // Strategy matching uses the extracted verb (skips VAR=value prefixes).
         foreach (var strategy in _strategies)
         {
             if (strategy.CanHandle(verb))
                 return strategy.Rewrite(tokens, context);
         }
 
-        if (context.GenericWrapperEnabled)
+        if (allowGenericWrapper && context.GenericWrapperEnabled)
             return genericWrapper.Rewrite(tokens, context);
 
         return RewriteDecision.Passthrough();
@@ -82,7 +118,7 @@ public sealed class CommandRewriteRegistry(
                 continue;
 
             var raw = string.Join("", segment.Tokens.Select(t => t.Value)).Trim();
-            var decision = RewriteSegment(segment.Tokens, raw, context);
+            var decision = RewriteSegment(segment.Tokens, context);
 
             if (decision.Outcome == RewriteOutcome.Deny)
                 return RewriteDecision.Deny();
@@ -98,6 +134,89 @@ public sealed class CommandRewriteRegistry(
 
         var joined = string.Join(" ", parts);
         return RewriteDecision.Rewritten(joined);
+    }
+
+    /// <summary>
+    /// Split tokens at the first pipe. <paramref name="pipeSuffix"/> includes leading
+    /// whitespace before the pipe, the pipe token, and the consumer side so reassembly
+    /// preserves spacing (<c>cmd | consumer</c>).
+    /// </summary>
+    private static bool TrySplitAtFirstPipe(
+        IReadOnlyList<ShellToken> tokens,
+        out IReadOnlyList<ShellToken> producerTokens,
+        out string? pipeSuffix)
+    {
+        for (var i = 0; i < tokens.Count; i++)
+        {
+            if (tokens[i].Kind != TokenKind.Pipe)
+                continue;
+
+            var producerEnd = i;
+            while (producerEnd > 0 && tokens[producerEnd - 1].Kind == TokenKind.Whitespace)
+                producerEnd--;
+
+            producerTokens = tokens.Take(producerEnd).ToList();
+            pipeSuffix = string.Join("", tokens.Skip(producerEnd).Select(t => t.Value));
+            return true;
+        }
+
+        producerTokens = tokens;
+        pipeSuffix = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Split a simple command (no pipes) into core tokens and a trailing redirect
+    /// suffix. Safe trailing plumbing today is only <c>2>&1</c> (stderr merge).
+    /// stdout/stdin redirects and redirects with targets stay unsafe → caller passthroughs.
+    /// The suffix includes leading whitespace so reassembly yields <c>cmd 2>&1</c>.
+    /// </summary>
+    private static bool TrySplitTrailingRedirects(
+        IReadOnlyList<ShellToken> tokens,
+        out IReadOnlyList<ShellToken> coreTokens,
+        out string? redirectSuffix,
+        out bool redirectsSafe)
+    {
+        coreTokens = tokens;
+        redirectSuffix = null;
+        redirectsSafe = true;
+
+        var firstRedirect = -1;
+        for (var i = 0; i < tokens.Count; i++)
+        {
+            if (tokens[i].Kind == TokenKind.Redirect)
+            {
+                firstRedirect = i;
+                break;
+            }
+        }
+
+        if (firstRedirect < 0)
+            return true;
+
+        // Everything from the first redirect to the end must be safe trailing plumbing.
+        // Safe: whitespace and Redirect("2>&1") only. Any other redirect, or any arg
+        // (redirect target), is unsafe / non-trailing.
+        for (var i = firstRedirect; i < tokens.Count; i++)
+        {
+            var kind = tokens[i].Kind;
+            if (kind == TokenKind.Whitespace)
+                continue;
+
+            if (kind == TokenKind.Redirect && tokens[i].Value == "2>&1")
+                continue;
+
+            redirectsSafe = false;
+            return true;
+        }
+
+        var coreEnd = firstRedirect;
+        while (coreEnd > 0 && tokens[coreEnd - 1].Kind == TokenKind.Whitespace)
+            coreEnd--;
+
+        coreTokens = tokens.Take(coreEnd).ToList();
+        redirectSuffix = string.Join("", tokens.Skip(coreEnd).Select(t => t.Value));
+        return true;
     }
 
     private static IReadOnlyList<Segment> SplitOnOperators(IReadOnlyList<ShellToken> tokens)

--- a/tests/Hypa.UnitTests/Application/HookServiceTests.cs
+++ b/tests/Hypa.UnitTests/Application/HookServiceTests.cs
@@ -145,11 +145,20 @@ public sealed class WhenGenericWrapperEnabled
         Assert.IsType<HookDecision.Passthrough>(decision);
     }
 
+    [Fact]
+    public async Task FirstClassProducer_WithPipe_ReturnsRewrite()
+    {
+        // Issue #83: left-of-pipe first-class producers rewrite; consumer stays raw.
+        var decision = await _service.ProcessAsync(MakeInput("git log | grep fix"));
+        var rewrite = Assert.IsType<HookDecision.Rewrite>(decision);
+        Assert.Equal("hypa git log | grep fix", rewrite.Command);
+    }
+
     [Theory]
-    [InlineData("git log | grep fix")]
     [InlineData("cat file.txt > output.txt")]
     [InlineData("echo $(git rev-parse HEAD)")]
-    public async Task ShellismOrPipe_PreservesPassthrough_WhenRegistryCannotSafelyRewrite(string command)
+    [InlineData("cat file | grep foo")]
+    public async Task ShellismOrUnsafePlumbing_PreservesPassthrough(string command)
     {
         var decision = await _service.ProcessAsync(MakeInput(command));
         Assert.IsType<HookDecision.Passthrough>(decision);

--- a/tests/Hypa.UnitTests/Infrastructure/CommandRewriteRegistryTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/CommandRewriteRegistryTests.cs
@@ -277,6 +277,8 @@ public sealed class CommandRewriteRegistryTests
     [InlineData("docker logs container >> log.txt")]
     [InlineData("kubectl get pods > pods.txt")]
     [InlineData("git log < rev-list.txt")]
+    [InlineData("git log --oneline | grep fix > out.txt")]
+    [InlineData("git status | cat > out.txt")]
     public void FirstClassCommand_WithUnsafeRedirect_ReturnsPassthrough(string input)
     {
         var registry = BuildRegistry();

--- a/tests/Hypa.UnitTests/Infrastructure/CommandRewriteRegistryTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/CommandRewriteRegistryTests.cs
@@ -40,6 +40,7 @@ public sealed class CommandRewriteRegistryTests
     [InlineData("git status", "hypa git status")]
     [InlineData("git diff HEAD~1", "hypa git diff HEAD~1")]
     [InlineData("git log --oneline", "hypa git log --oneline")]
+    [InlineData("git log --oneline -100", "hypa git log --oneline -100")]
     [InlineData("git --no-pager diff --staged", "hypa git --no-pager diff --staged")]
     [InlineData("git -P diff --staged", "hypa git -P diff --staged")]
     [InlineData("git --paginate diff --staged", "hypa git --paginate diff --staged")]
@@ -112,8 +113,10 @@ public sealed class CommandRewriteRegistryTests
     }
 
     [Fact]
-    public void Pipe_ReturnsPassthrough()
+    public void Pipe_WithoutFirstClassProducer_ReturnsPassthrough()
     {
+        // Unknown producers must not be generic-wrapped when piped — consumers
+        // often require native line format (grep, path listers, etc.).
         var registry = BuildRegistry();
         var result = registry.Rewrite("cat file | grep foo", DefaultContext);
         Assert.Equal(RewriteOutcome.Passthrough, result.Outcome);
@@ -145,19 +148,30 @@ public sealed class CommandRewriteRegistryTests
     }
 
     [Fact]
-    public void CompoundCommand_WithCdBuiltin_ReturnsPassthrough()
+    public void CompoundCommand_WithCdBuiltin_RewritesOtherSegments()
     {
         var registry = BuildRegistry();
-        var result = registry.Rewrite("cd /tmp && pwd", DefaultContext);
-        Assert.Equal(RewriteOutcome.Passthrough, result.Outcome);
+        var result = registry.Rewrite("cd dir && git log --oneline", DefaultContext);
+        Assert.Equal(RewriteOutcome.Rewritten, result.Outcome);
+        Assert.Equal("cd dir && hypa git log --oneline", result.Command);
     }
 
     [Fact]
-    public void CompoundCommand_WithExportBuiltin_ReturnsPassthrough()
+    public void CompoundCommand_WithExportBuiltin_RewritesOtherSegments()
     {
         var registry = BuildRegistry();
-        var result = registry.Rewrite("export FOO=bar && echo hi", DefaultContext);
-        Assert.Equal(RewriteOutcome.Passthrough, result.Outcome);
+        var result = registry.Rewrite("export FOO=bar && git status", DefaultContext);
+        Assert.Equal(RewriteOutcome.Rewritten, result.Outcome);
+        Assert.Equal("export FOO=bar && hypa git status", result.Command);
+    }
+
+    [Fact]
+    public void CompoundCommand_WithCdBuiltin_AndGenericSegment_RewritesGeneric()
+    {
+        var registry = BuildRegistry();
+        var result = registry.Rewrite("cd /tmp && pwd", DefaultContext);
+        Assert.Equal(RewriteOutcome.Rewritten, result.Outcome);
+        Assert.Equal("cd /tmp && hypa -c \"pwd\"", result.Command);
     }
 
     [Fact]
@@ -169,11 +183,12 @@ public sealed class CommandRewriteRegistryTests
     }
 
     [Fact]
-    public void CompoundCommand_WithMultipleEnvPrefixesAndCd_ReturnsPassthrough()
+    public void CompoundCommand_WithMultipleEnvPrefixesAndCd_RewritesOtherSegments()
     {
         var registry = BuildRegistry();
-        var result = registry.Rewrite("FOO=bar BAZ=1 cd /tmp && pwd", DefaultContext);
-        Assert.Equal(RewriteOutcome.Passthrough, result.Outcome);
+        var result = registry.Rewrite("FOO=bar BAZ=1 cd /tmp && git status", DefaultContext);
+        Assert.Equal(RewriteOutcome.Rewritten, result.Outcome);
+        Assert.Equal("FOO=bar BAZ=1 cd /tmp && hypa git status", result.Command);
     }
 
     [Fact]
@@ -185,11 +200,12 @@ public sealed class CommandRewriteRegistryTests
     }
 
     [Fact]
-    public void CompoundCommand_WithStatefulBuiltinAfterRewrittenSegment_ReturnsPassthrough()
+    public void CompoundCommand_WithStatefulBuiltinAfterRewrittenSegment_RewritesFirstSegment()
     {
         var registry = BuildRegistry();
         var result = registry.Rewrite("git status && cd /tmp", DefaultContext);
-        Assert.Equal(RewriteOutcome.Passthrough, result.Outcome);
+        Assert.Equal(RewriteOutcome.Rewritten, result.Outcome);
+        Assert.Equal("hypa git status && cd /tmp", result.Command);
     }
 
     [Theory]
@@ -240,18 +256,75 @@ public sealed class CommandRewriteRegistryTests
         Assert.Equal(RewriteOutcome.GenericWrapper, result.Outcome);
     }
 
-    // --- Redirect passthrough ---
+    // --- Safe trailing redirects (stderr merge) ---
+
+    [Theory]
+    [InlineData("git status 2>&1", "hypa git status 2>&1")]
+    [InlineData("dotnet test 2>&1", "hypa dotnet test 2>&1")]
+    [InlineData("git log --oneline 2>&1", "hypa git log --oneline 2>&1")]
+    public void FirstClassCommand_WithStderrMerge_RewritesAndPreservesRedirect(string input, string expected)
+    {
+        var registry = BuildRegistry();
+        var result = registry.Rewrite(input, DefaultContext);
+        Assert.Equal(RewriteOutcome.Rewritten, result.Outcome);
+        Assert.Equal(expected, result.Command);
+    }
+
+    // --- Unsafe redirects (stdout/stdin / write targets) stay passthrough ---
 
     [Theory]
     [InlineData("git status > out.txt")]
-    [InlineData("dotnet test 2>&1")]
     [InlineData("docker logs container >> log.txt")]
     [InlineData("kubectl get pods > pods.txt")]
-    public void FirstClassCommand_WithRedirect_ReturnsPassthrough(string input)
+    [InlineData("git log < rev-list.txt")]
+    public void FirstClassCommand_WithUnsafeRedirect_ReturnsPassthrough(string input)
     {
         var registry = BuildRegistry();
         var result = registry.Rewrite(input, DefaultContext);
         Assert.Equal(RewriteOutcome.Passthrough, result.Outcome);
+    }
+
+    // --- Pipes: left-of-pipe rewrite for first-class producers ---
+
+    [Theory]
+    [InlineData("git log --oneline | head -20", "hypa git log --oneline | head -20")]
+    [InlineData("git log --oneline -100 2>&1 | tail -3", "hypa git log --oneline -100 2>&1 | tail -3")]
+    [InlineData("git status | cat", "hypa git status | cat")]
+    [InlineData("dotnet test 2>&1 | tail -20", "hypa dotnet test 2>&1 | tail -20")]
+    public void FirstClassCommand_WithPipe_RewritesProducer(string input, string expected)
+    {
+        var registry = BuildRegistry();
+        var result = registry.Rewrite(input, DefaultContext);
+        Assert.Equal(RewriteOutcome.Rewritten, result.Outcome);
+        Assert.Equal(expected, result.Command);
+    }
+
+    [Fact]
+    public void FirstClassCommand_UnsupportedSubcommand_WithPipe_ReturnsPassthrough()
+    {
+        var registry = BuildRegistry();
+        var result = registry.Rewrite("git push origin main | cat", DefaultContext);
+        Assert.Equal(RewriteOutcome.Passthrough, result.Outcome);
+    }
+
+    // --- Combined agent forms (cd + pipe + redirect) ---
+
+    [Fact]
+    public void CompoundCommand_CdAndGitLogWithPipe_RewritesGitProducer()
+    {
+        var registry = BuildRegistry();
+        var result = registry.Rewrite("cd dir && git log --oneline | head -20", DefaultContext);
+        Assert.Equal(RewriteOutcome.Rewritten, result.Outcome);
+        Assert.Equal("cd dir && hypa git log --oneline | head -20", result.Command);
+    }
+
+    [Fact]
+    public void CompoundCommand_CdAndGitLogWithRedirectAndPipe_RewritesGitProducer()
+    {
+        var registry = BuildRegistry();
+        var result = registry.Rewrite("cd dir && git log --oneline -100 2>&1 | tail -3", DefaultContext);
+        Assert.Equal(RewriteOutcome.Rewritten, result.Outcome);
+        Assert.Equal("cd dir && hypa git log --oneline -100 2>&1 | tail -3", result.Command);
     }
 
     // --- Shellism passthrough ---


### PR DESCRIPTION
## Summary

Fix command rewrite over-passthrough for common agent shell forms so first-class reducers and compression apply when safe.

**Before:** any compound with a stateful builtin (`cd`, `export`, …), any pipe, or any redirect forced Passthrough — agents never got `hypa git …` for `cd dir && git log`, `git log | head`, or `git status 2>&1`.

**After (registry is sole rewrite source):**
- **Compounds** (`&&` / `||` / `;`): rewrite each segment independently; leave stateful builtins raw; keep whole-command Passthrough only for reserved words / shellisms.
- **Pipes:** rewrite left-of-pipe **first-class** producers; leave consumers raw; do **not** generic-wrap pipe producers.
- **Redirects:** peel/re-append safe trailing `2>&1`; Passthrough on any other redirect (`>`, `>>`, `<`, `<<`) including on pipe consumers.
- **Ask** outcomes propagate from compound segments (not silently upgraded to Rewritten).

## Examples

| Input | Result |
| --- | --- |
| `cd dir && git log --oneline` | `cd dir && hypa git log --oneline` |
| `export FOO=bar && git status` | `export FOO=bar && hypa git status` |
| `git log --oneline \| head -20` | `hypa git log --oneline \| head -20` |
| `git log --oneline -100 2>&1 \| tail -3` | `hypa git log --oneline -100 2>&1 \| tail -3` |
| `git status 2>&1` | `hypa git status 2>&1` |
| `git status > out.txt` | Passthrough |
| `cat file \| grep foo` | Passthrough (non-first-class pipe producer) |
| `cd /tmp` | Passthrough |
| `if …; then …; fi` | Passthrough |

## Test plan

- [x] `dotnet test tests/Hypa.UnitTests --filter "FullyQualifiedName~CommandRewriteRegistryTests|FullyQualifiedName~HookServiceTests|FullyQualifiedName~WhenGenericWrapperEnabled"` — 85 passed
- [x] Updated registry unit tests for compounds / pipes / `2>&1` / unsafe redirects
- [x] Updated hook service tests for left-of-pipe first-class rewrite
- Note: `CodeStructureProviderRegistryTests.Select_ForMarkdown_ReturnsMarkdownProvider` fails on main independently of this change

## Codex review

- Model: `gpt-5.6-luna` with `model_reasoning_effort=xhigh`
- Verdict: **pass_after_fix**
- Fixed: unsafe redirects on pipe consumers; Ask propagation in compounds
- Residual (accepted): reserved words only as pipe consumers stay raw by design (valid shell); non-redirect writers like `tee` out of scope

Closes #83
