### PR TITLE
Fix macOS hypa_read sed slicing and git worktree project-root detection

### DIFF
--- a/packages/pi-hypa/extensions/tools.ts
+++ b/packages/pi-hypa/extensions/tools.ts
@@ -187,13 +187,18 @@ function normalizePathArg(path: string): string {
 }
 
 export function buildReadCommand(path: string, offset?: number, limit?: number): string {
-  const quotedPath = shellQuote(normalizePathArg(path));
+  const normalized = normalizePathArg(path);
   if (offset !== undefined || limit !== undefined) {
     const start = Math.max(1, Math.floor(offset ?? 1));
     const end = limit !== undefined ? start + Math.max(1, Math.floor(limit)) - 1 : "$";
-    return `sed -n ${shellQuote(`${start},${end}p`)} -- ${quotedPath}`;
+    // BSD sed has no `--` end-of-options (macOS treats `--` as a filename).
+    // cat/grep/ls keep `--`; find is separate. Leading-dash relative paths get a
+    // `./` prefix so sed does not parse them as options (shell quoting alone does
+    // not help argv flags).
+    const sedPath = normalized.startsWith("-") ? `./${normalized}` : normalized;
+    return `sed -n ${shellQuote(`${start},${end}p`)} ${shellQuote(sedPath)}`;
   }
-  return `cat -- ${quotedPath}`;
+  return `cat -- ${shellQuote(normalized)}`;
 }
 
 /**

--- a/packages/pi-hypa/test/tools.test.ts
+++ b/packages/pi-hypa/test/tools.test.ts
@@ -35,8 +35,28 @@ test("shellQuote uses cmd-style double quotes on Windows", () => {
 });
 
 test("buildReadCommand uses cat by default and sed for line slices", () => {
+  const home = homedir();
   assert.equal(buildReadCommand("src/File.cs"), "cat -- src/File.cs");
-  assert.equal(buildReadCommand("src/File.cs", 10, 5), "sed -n 10,14p -- src/File.cs");
+  // offset + limit
+  assert.equal(buildReadCommand("src/File.cs", 10, 5), "sed -n 10,14p src/File.cs");
+  // offset only → end is $ (shellQuote wraps the range because $ is not safe-unquoted)
+  assert.equal(buildReadCommand("src/File.cs", 10), `sed -n ${shellQuote("10,$p")} src/File.cs`);
+  // limit only → start defaults to 1
+  assert.equal(buildReadCommand("src/File.cs", undefined, 5), "sed -n 1,5p src/File.cs");
+  // path with spaces requires quoting (shellQuote is platform-aware)
+  assert.equal(
+    buildReadCommand("src/My File.cs", 10, 5),
+    `sed -n 10,14p ${shellQuote("src/My File.cs")}`,
+  );
+  // leading-dash relative path: BSD sed has no `--`, so prefix ./
+  assert.equal(buildReadCommand("-report.txt", 1, 5), "sed -n 1,5p ./-report.txt");
+  // absolute paths starting with / need no ./ prefix
+  assert.equal(buildReadCommand("/tmp/-report.txt", 1, 5), "sed -n 1,5p /tmp/-report.txt");
+  // tilde expands on the sed branch too
+  assert.equal(
+    buildReadCommand("~/notes.txt", 2, 3),
+    `sed -n 2,4p ${shellQuote(`${home}/notes.txt`)}`,
+  );
 });
 
 test("buildGrepCommand includes safe ripgrep options", () => {

--- a/src/Hypa.Infrastructure/ProjectRoot/GitProjectRootDetector.cs
+++ b/src/Hypa.Infrastructure/ProjectRoot/GitProjectRootDetector.cs
@@ -18,7 +18,10 @@ public sealed class GitProjectRootDetector : IProjectRootDetector
 
     private static bool HasMarker(DirectoryInfo dir)
     {
-        if (Directory.Exists(Path.Combine(dir.FullName, ".git"))) return true;
+        // Normal repos use a `.git` directory. Worktrees and submodules use a `.git`
+        // *file* (`gitdir: ...` / `gitdir: ../.git/modules/...`). Either form marks a root.
+        var gitPath = Path.Combine(dir.FullName, ".git");
+        if (Directory.Exists(gitPath) || File.Exists(gitPath)) return true;
         if (Directory.Exists(Path.Combine(dir.FullName, ".hypa"))) return true;
         if (dir.GetFiles("*.sln").Length > 0) return true;
         if (dir.GetFiles("*.slnx").Length > 0) return true;

--- a/tests/Hypa.UnitTests/Infrastructure/GitProjectRootDetectorTests.cs
+++ b/tests/Hypa.UnitTests/Infrastructure/GitProjectRootDetectorTests.cs
@@ -23,6 +23,49 @@ public sealed class GitProjectRootDetectorTests : IDisposable
     }
 
     [Fact]
+    public void Detect_GitWorktreeFile_ReturnsRoot()
+    {
+        // Git worktrees place a `.git` file (not directory) with a gitdir: pointer.
+        File.WriteAllText(Path.Combine(_tempDir, ".git"), "gitdir: /some/path/.git/worktrees/feature\n");
+        var nested = Path.Combine(_tempDir, "src", "nested");
+        Directory.CreateDirectory(nested);
+
+        var detector = new GitProjectRootDetector();
+        Assert.Equal(_tempDir, detector.Detect(nested));
+        // Starting at the worktree root itself also resolves.
+        Assert.Equal(_tempDir, detector.Detect(_tempDir));
+    }
+
+    [Fact]
+    public void Detect_GitSubmoduleFile_ReturnsRoot()
+    {
+        // Submodules also use a `.git` file pointing into the superproject modules dir.
+        File.WriteAllText(Path.Combine(_tempDir, ".git"), "gitdir: ../.git/modules/vendor/lib\n");
+        var nested = Path.Combine(_tempDir, "src");
+        Directory.CreateDirectory(nested);
+
+        var result = new GitProjectRootDetector().Detect(nested);
+
+        Assert.Equal(_tempDir, result);
+    }
+
+    [Fact]
+    public void Detect_GitFile_NearestWinsOverParentMarker()
+    {
+        // Outer project has a non-git marker; nested worktree/submodule has a `.git` file.
+        File.WriteAllText(Path.Combine(_tempDir, "Outer.sln"), "");
+        var child = Path.Combine(_tempDir, "vendor", "lib");
+        Directory.CreateDirectory(child);
+        File.WriteAllText(Path.Combine(child, ".git"), "gitdir: ../../.git/modules/vendor/lib\n");
+        var deep = Path.Combine(child, "src");
+        Directory.CreateDirectory(deep);
+
+        var result = new GitProjectRootDetector().Detect(deep);
+
+        Assert.Equal(child, result);
+    }
+
+    [Fact]
     public void Detect_SlnFile_ReturnsRoot()
     {
         File.WriteAllText(Path.Combine(_tempDir, "MyApp.sln"), "");


### PR DESCRIPTION
## Summary

Fixes two independent macOS bugs reported in #89:

1. **`hypa_read` offset/limit on BSD sed** — `buildReadCommand()` no longer passes `--` to `sed` (BSD sed treats it as a filename). Relative paths starting with `-` get a `./` prefix so sed does not parse them as options. `cat --` is unchanged.
2. **Git worktree project root** — `GitProjectRootDetector` now treats a `.git` *file* (worktrees/submodules) as a root marker, not only a `.git` directory.

Bare-name spawn resolving non-executable cwd files is intentionally **out of scope** (follow-up).

## Test plan

- [x] `dotnet test tests/Hypa.UnitTests --filter FullyQualifiedName~GitProjectRootDetector` (9 passed)
- [x] `cd packages/pi-hypa && npm test` (78 passed)
- [x] Implement skill review loop (general + tests) → 0 open issues
- [x] Final Codex xhigh pre-PR review → `NO_BLOCKING_ISSUES`

Closes #89