### PR TITLE
Exclude AOT debug sidecars from release packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,23 @@ jobs:
 
           New-Item -ItemType Directory -Force -Path $packageRoot, $distDir | Out-Null
           Copy-Item (Join-Path $publishDir "*") -Destination $packageRoot -Recurse
+
+          # StripSymbols=true moves AOT debug info out of the binary into
+          # platform sidecars (macOS .dSYM, Linux .dbg, Windows .pdb). Those are
+          # not needed at runtime and bloat GitHub releases, npm platform
+          # packages, and PyPI wheels — remove them before archiving.
+          Get-ChildItem -Path $packageRoot -Directory -Filter '*.dSYM' -Recurse -Force -ErrorAction SilentlyContinue |
+            ForEach-Object {
+              Write-Host "Excluding debug artifact: $($_.FullName)"
+              Remove-Item -LiteralPath $_.FullName -Recurse -Force
+            }
+          Get-ChildItem -Path $packageRoot -File -Recurse -Force -ErrorAction SilentlyContinue |
+            Where-Object { $_.Extension -in '.pdb', '.dbg' } |
+            ForEach-Object {
+              Write-Host "Excluding debug artifact: $($_.FullName)"
+              Remove-Item -LiteralPath $_.FullName -Force
+            }
+
           if ($archive -eq "tar.gz") {
             chmod +x (Join-Path $packageRoot $executable)
             tar -czf (Join-Path $distDir "hypa-$rid.tar.gz") -C "artifacts/package" "hypa-$rid"
@@ -328,6 +345,11 @@ jobs:
             else
               unzip -j "dist-artifacts/hypa-${RID}.zip" "hypa-${RID}/*" -d "${STAGE}/bin"
             fi
+
+            # Defense in depth: drop AOT debug sidecars if an older archive still
+            # contains them (macOS .dSYM bundles, Windows .pdb, Linux .dbg).
+            find "${STAGE}/bin" -depth -name '*.dSYM' -type d -exec rm -rf {} +
+            find "${STAGE}/bin" \( -name '*.pdb' -o -name '*.dbg' \) -type f -delete
 
             jq \
               --arg name "@hypabolic/hypa-${NPM}" \

--- a/python/scripts/build_wheel.py
+++ b/python/scripts/build_wheel.py
@@ -70,7 +70,12 @@ def main():
                 parts = member.name.split("/", 1)
                 if len(parts) < 2 or not parts[1]:
                     continue
-                member.name = parts[1]
+                # Skip AOT debug sidecars (macOS .dSYM, Linux .dbg, Windows .pdb)
+                # so wheels stay runtime-only even if an archive still has them.
+                rel = parts[1]
+                if ".dSYM/" in rel or rel.endswith(".dSYM") or rel.endswith((".pdb", ".dbg")):
+                    continue
+                member.name = rel
                 tf.extract(member, bin_dir)
 
         # 4. Build a generic wheel

--- a/src/Hypa.Cli/Hypa.Cli.csproj
+++ b/src/Hypa.Cli/Hypa.Cli.csproj
@@ -8,6 +8,8 @@
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
     <PublishSingleFile>true</PublishSingleFile>
+    <!-- Keep the native binary small; release packaging must not ship the
+         resulting .dSYM / .dbg / .pdb sidecars (see .github/workflows/release.yml). -->
     <StripSymbols>true</StripSymbols>
     <InvariantGlobalization>true</InvariantGlobalization>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
## Summary

`PublishAot` + `StripSymbols` writes platform debug sidecars beside the native binary (macOS `*.dSYM`, Linux `*.dbg`, Windows `*.pdb`). Release packaging copied the entire publish tree into archives, so those files landed in:

- GitHub release tarballs/zips
- `@hypabolic/hypa-*` npm platform packages (e.g. `bin/hypa.dSYM/...`)
- PyPI platform wheels

That inflated `@hypabolic/hypa-darwin-x64` enough that cnpm/npmmirror rejected sync (see #90: ~188 MB vs 80 MB allow). None of the sidecars are needed at runtime — the executable is already stripped.

### Changes
1. **Primary:** after copy in the release Package step, delete `*.dSYM` directories and `*.pdb` / `*.dbg` files **before** archiving.
2. **Defense in depth:** npm platform staging and PyPI wheel extract skip the same artifacts if an archive still contains them.
3. Comment on `StripSymbols` in `Hypa.Cli.csproj` pointing at the packaging rule.

Historic published versions (e.g. 0.1.5) cannot be rewritten; this applies from the next release onward.

## Test plan
- [x] Python extract filter smoke-checked against sample paths
- [ ] Next release build: confirm package logs show excluded artifacts (or none present) and npm tarball has no `*.dSYM`
- [ ] Spot-check that `bin/hypa` (and grammar dylib/so) still ship

Closes #90