### PR TITLE
Emit pi-hypa:file-read process event when hypa_read is called

### DIFF
--- a/packages/pi-hypa/extensions/index.ts
+++ b/packages/pi-hypa/extensions/index.ts
@@ -1,9 +1,10 @@
+import * as path from "node:path";
 import { isToolCallEventType, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { formatStatus, loadConfig, resolveConfigFilePath } from "./policy.js";
 import { resolveHypaBinary, rewriteCommand } from "./rewrite-client.js";
 import { registerHypaMcpProxyBridge } from "./mcp-proxy-bridge.js";
-import { registerHypaTools } from "./tools.js";
-import type { HypaDiagnostics, RewriteStatus } from "./types.js";
+import { registerHypaTools, normalizePathArg } from "./tools.js";
+import type { HypaDiagnostics, HypaFileReadEvent, RewriteStatus } from "./types.js";
 
 export const REPLACE_MODE_DISABLED_BUILTINS = new Set(["bash", "read", "grep", "find", "ls"]);
 
@@ -79,6 +80,33 @@ export default function (pi: ExtensionAPI) {
         };
       }
     }
+  });
+
+  // Emit a process-level event for every hypa_read tool call so that
+  // consumers like pi-lens can forward the read to their internal read-guard
+  // and satisfy the "read before edit" requirement.
+  // See: HypaFileReadEvent in types.ts for the event payload shape.
+  pi.on("tool_call", async (event, ctx) => {
+    if (event.toolName !== "hypa_read") return;
+
+    const rawPath = event.input?.path;
+    if (typeof rawPath !== "string" || !rawPath) return;
+
+    const normalized = normalizePathArg(rawPath);
+    const cwd = ctx?.cwd ?? process.cwd();
+    const filePath = path.isAbsolute(normalized) ? normalized : path.resolve(cwd, normalized);
+
+    const offset = event.input?.offset;
+    const limit = event.input?.limit;
+
+    const readEvent: HypaFileReadEvent = {
+      filePath,
+      requestedOffset: typeof offset === "number" ? Math.max(1, Math.floor(offset)) : 1,
+      requestedLimit: typeof limit === "number" ? Math.max(1, Math.floor(limit)) : undefined,
+      timestamp: Date.now(),
+    };
+
+    (process as NodeJS.EventEmitter).emit("pi-hypa:file-read", readEvent);
   });
 
   pi.registerCommand("hypa", {

--- a/packages/pi-hypa/extensions/tools.ts
+++ b/packages/pi-hypa/extensions/tools.ts
@@ -173,7 +173,7 @@ export function shellQuote(value: string, platformName: NodeJS.Platform = platfo
   return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
-function normalizePathArg(path: string): string {
+export function normalizePathArg(path: string): string {
   // A leading "@" is an artifact of pi's file-mention syntax; strip it first.
   const unprefixed = path.startsWith("@") ? path.slice(1) : path;
   // Expand a leading "~" to the home directory, mirroring pi's native file

--- a/packages/pi-hypa/extensions/types.ts
+++ b/packages/pi-hypa/extensions/types.ts
@@ -33,6 +33,30 @@ export interface HypaPiConfig {
   piMcpConfigPath?: string;
 }
 
+/**
+ * Emitted on the Node.js `process` EventEmitter as `"pi-hypa:file-read"` each
+ * time the `hypa_read` tool is invoked. Consumers such as pi-lens can listen
+ * for this event and forward the information to their internal read-guard so
+ * that a subsequent `edit` call on the same file is not blocked.
+ *
+ * @example
+ * ```ts
+ * process.on("pi-hypa:file-read", (event: HypaFileReadEvent) => {
+ *   readGuard.recordRead({ filePath: event.filePath, ... });
+ * });
+ * ```
+ */
+export interface HypaFileReadEvent {
+  /** Absolute path to the file being read. */
+  filePath: string;
+  /** First line requested (1-indexed). Defaults to 1 when no offset was given. */
+  requestedOffset: number;
+  /** Number of lines requested. `undefined` means the whole file was requested. */
+  requestedLimit: number | undefined;
+  /** Unix timestamp (ms) captured at the moment the tool_call event fired. */
+  timestamp: number;
+}
+
 export interface HypaDiagnostics {
   mode: HypaPiMode;
   configFilePath?: string;

--- a/packages/pi-hypa/test/read-bridge.test.ts
+++ b/packages/pi-hypa/test/read-bridge.test.ts
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import * as path from "node:path";
+import type { HypaFileReadEvent } from "../extensions/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers — simulate the tool_call handler logic in isolation
+// ---------------------------------------------------------------------------
+
+function normalizePathArg(p: string): string {
+  const unprefixed = p.startsWith("@") ? p.slice(1) : p;
+  if (unprefixed === "~") return homedir();
+  if (unprefixed.startsWith("~/")) return homedir() + unprefixed.slice(1);
+  return unprefixed;
+}
+
+function buildReadEvent(
+  rawPath: string,
+  offset?: number,
+  limit?: number,
+  cwd = "/project",
+): HypaFileReadEvent {
+  const normalized = normalizePathArg(rawPath);
+  const filePath = path.isAbsolute(normalized) ? normalized : path.resolve(cwd, normalized);
+  return {
+    filePath,
+    requestedOffset: typeof offset === "number" ? Math.max(1, Math.floor(offset)) : 1,
+    requestedLimit: typeof limit === "number" ? Math.max(1, Math.floor(limit)) : undefined,
+    timestamp: Date.now(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("buildReadEvent resolves relative paths against cwd", () => {
+  const evt = buildReadEvent("src/main.go", undefined, undefined, "/project");
+  assert.equal(evt.filePath, "/project/src/main.go");
+  assert.equal(evt.requestedOffset, 1);
+  assert.equal(evt.requestedLimit, undefined);
+});
+
+test("buildReadEvent keeps absolute paths as-is", () => {
+  const evt = buildReadEvent("/tmp/foo.ts");
+  assert.equal(evt.filePath, "/tmp/foo.ts");
+});
+
+test("buildReadEvent expands tilde to home directory", () => {
+  const evt = buildReadEvent("~/notes.md");
+  assert.equal(evt.filePath, path.join(homedir(), "notes.md"));
+});
+
+test("buildReadEvent strips leading @ from file-mention paths", () => {
+  const evt = buildReadEvent("@src/main.go", undefined, undefined, "/project");
+  assert.equal(evt.filePath, "/project/src/main.go");
+});
+
+test("buildReadEvent clamps offset to minimum 1", () => {
+  const evt = buildReadEvent("file.ts", 0);
+  assert.equal(evt.requestedOffset, 1);
+
+  const evt2 = buildReadEvent("file.ts", -5);
+  assert.equal(evt2.requestedOffset, 1);
+});
+
+test("buildReadEvent clamps limit to minimum 1", () => {
+  const evt = buildReadEvent("file.ts", 1, 0);
+  assert.equal(evt.requestedLimit, 1);
+});
+
+test("buildReadEvent floors fractional offset and limit", () => {
+  const evt = buildReadEvent("file.ts", 3.9, 10.7);
+  assert.equal(evt.requestedOffset, 3);
+  assert.equal(evt.requestedLimit, 10);
+});
+
+test("buildReadEvent produces undefined requestedLimit when no limit given", () => {
+  const evt = buildReadEvent("file.ts", 5);
+  assert.equal(evt.requestedLimit, undefined);
+});
+
+test("process emits pi-hypa:file-read event with correct shape", async () => {
+  const received: HypaFileReadEvent[] = [];
+  const listener = (evt: HypaFileReadEvent) => received.push(evt);
+
+  process.on("pi-hypa:file-read", listener as (...args: unknown[]) => void);
+  try {
+    const evt = buildReadEvent("src/handler.go", 10, 50, "/myproject");
+    (process as NodeJS.EventEmitter).emit("pi-hypa:file-read", evt);
+
+    assert.equal(received.length, 1);
+    assert.equal(received[0].filePath, "/myproject/src/handler.go");
+    assert.equal(received[0].requestedOffset, 10);
+    assert.equal(received[0].requestedLimit, 50);
+    assert.ok(typeof received[0].timestamp === "number");
+  } finally {
+    process.off("pi-hypa:file-read", listener as (...args: unknown[]) => void);
+  }
+});


### PR DESCRIPTION
## Problem

The `hypa_read` tool is invisible to pi-lens's read-before-edit guard. Pi-lens tracks reads by intercepting specific tool events (`read`, `bash cat/sed -n`, search tools) and calling `readGuard.recordRead()`. Since `hypa_read` is a custom registered tool that runs via `pi.exec()` rather than through the bash tool, pi-lens never sees it — so a subsequent `edit` on the same file is blocked with:

> 🔄 RETRYABLE — Edit without read
> You are trying to edit `<file>` but have not read it in this conversation.

## Solution

Add a `tool_call` listener for `hypa_read` that emits a `"pi-hypa:file-read"` event on the Node.js `process` EventEmitter. The event carries the resolved absolute file path, the requested offset and limit, and a timestamp.

Pi-lens (or any other consumer) can bridge this into its read-guard with:

```ts
process.on("pi-hypa:file-read", (evt: HypaFileReadEvent) => {
  readGuard.recordRead({
    filePath: evt.filePath,
    requestedOffset: evt.requestedOffset,
    requestedLimit: evt.requestedLimit ?? Infinity,
    effectiveOffset: evt.requestedOffset,
    effectiveLimit: evt.requestedLimit ?? Infinity,
    expandedByLsp: false,
    turnIndex: runtime.turnIndex,
    writeIndex: runtime.peekWriteIndex(),
    timestamp: evt.timestamp,
  });
});
```

## Changes

- **`extensions/types.ts`** — adds `HypaFileReadEvent` interface documenting the event payload
- **`extensions/tools.ts`** — exports `normalizePathArg` so index.ts can reuse it without duplicating the tilde/@ normalization logic
- **`extensions/index.ts`** — registers a `tool_call` listener that emits `"pi-hypa:file-read"` with a normalized absolute path whenever `hypa_read` is invoked
- **`test/read-bridge.test.ts`** — 9 new tests covering path normalization, clamping, and the process event shape

## Notes

- The emission is purely additive and a no-op if no listener is registered — no behavioural change for existing consumers.
- A companion PR to pi-lens is needed to register the listener and close the loop end-to-end.