### PR TITLE
Fix Pi raw mode accepting compound shell commands

### DIFF
--- a/packages/pi-hypa/extensions/tools.ts
+++ b/packages/pi-hypa/extensions/tools.ts
@@ -79,7 +79,7 @@ const shellSchema = {
   properties: {
     command: textParameter("Shell command to execute through Hypa compression"),
     timeoutMs: numberParameter("Timeout in milliseconds (default: Hypa CLI default)"),
-    raw: booleanParameter("Run with hypa raw instead of compressed hypa -c"),
+    raw: booleanParameter("Run a simple whitespace-tokenized command with hypa raw; omit for shell syntax, quoting, or multiline commands"),
   },
   required: ["command"],
   additionalProperties: false,
@@ -461,10 +461,14 @@ async function runHypaCommand(
   return pi.exec(execBin, execArgs, { signal, timeout: timeoutMs });
 }
 
-function splitRawCommand(command: string): string[] {
-  // Raw mode is intentionally conservative: pass through simple whitespace-tokenized commands only.
-  // Complex shell syntax should use compressed mode, where Hypa owns shell parsing.
-  return command.trim().split(/\s+/).filter(Boolean);
+export function splitRawCommand(command: string): string[] {
+  const trimmed = command.trim();
+  if (!trimmed || /[\r\n'"\\`$%&|;<>^!()]/.test(trimmed)) {
+    throw new Error(
+      "hypa_shell raw mode only supports a simple executable and whitespace-separated arguments; omit raw for shell syntax, quoting, or multiline commands",
+    );
+  }
+  return trimmed.split(/\s+/);
 }
 
 function hasOwn(obj: unknown, key: string): boolean {
@@ -606,6 +610,7 @@ export function registerHypaTools(pi: PiApi, config: HypaPiConfig) {
     promptSnippet: "Run shell commands through Hypa compression",
     promptGuidelines: [
       "Use hypa_shell for shell commands when compressed output is preferred.",
+      "Use raw mode only for a simple executable and whitespace-separated arguments; omit it for shell syntax, quoting, or multiline commands.",
       "Do not use hypa_shell to read files; use hypa_read instead.",
     ],
     parameters: shellSchema,

--- a/packages/pi-hypa/test/tools.test.ts
+++ b/packages/pi-hypa/test/tools.test.ts
@@ -12,6 +12,7 @@ import {
   limitStdoutLines,
   looksLikeOpaqueBinary,
   shellQuote,
+  splitRawCommand,
   tryBuildImageReadResult,
 } from "../extensions/tools.js";
 
@@ -32,6 +33,32 @@ test("shellQuote uses cmd-style double quotes on Windows", () => {
   assert.equal(shellQuote("^escape", "win32"), '"^escape"');
   // Trailing backslash before closing " is a known ShellLexer/StripQuotes limitation
   // outside this function's scope; do not use MSVC list2cmdline escaping here.
+});
+
+test("splitRawCommand accepts simple executable arguments", () => {
+  assert.deepEqual(splitRawCommand("  npm   test -- --runInBand  "), ["npm", "test", "--", "--runInBand"]);
+  assert.deepEqual(splitRawCommand("rg foo.* src"), ["rg", "foo.*", "src"]);
+});
+
+test("splitRawCommand rejects syntax that requires a shell", () => {
+  for (const command of [
+    "mkdir fixture && cd fixture",
+    "test -f file || echo missing",
+    "cat file | grep text",
+    "echo text > file",
+    "echo $HOME",
+    "echo %PATH%",
+    "echo hello^world",
+    "echo hello!",
+    "echo 'two words'",
+    'echo "two words"',
+    "printf foo\\n",
+    "echo one\necho two",
+    "(echo text)",
+    "",
+  ]) {
+    assert.throws(() => splitRawCommand(command), /omit raw for shell syntax, quoting, or multiline commands/);
+  }
 });
 
 test("buildReadCommand uses cat by default and sed for line slices", () => {


### PR DESCRIPTION
## Summary

- reject `hypa_shell` calls that combine `raw: true` with shell operators, redirects, quoting, substitutions, escapes, or multiline input
- clarify the raw-mode restriction in the tool schema and prompt guidance
- retain raw passthrough for simple whitespace-tokenized executable arguments

## Why

`hypa raw` receives an argv array after the user's interactive shell has parsed the command. The Pi adapter instead receives a command string and currently reconstructs argv with `split(/\s+/)`. Although the implementation comment says complex syntax must use compressed mode, the tool contract does not communicate or enforce that restriction.

For example, this Pi call:

```json
{"command":"mkdir fixture && cd fixture && git init","raw":true}
```

currently invokes `mkdir` with `fixture`, `&&`, `cd`, `fixture`, `&&`, `git`, and `init` as ordinary arguments. That can silently create unintended filesystem entries. The new validation fails before spawning Hypa and directs callers to omit `raw`, allowing compressed mode to own shell parsing.

## Validation

- `npm run build` — passes
- `npx tsx --test test/tools.test.ts` — 24/24 pass
- `npm test` — the new tests pass; the suite retains 3 unrelated failures on unmodified `main` in bundled-native binary resolution tests (`resolveBundledHypaBinary` / `resolveHypaBinary`)

No CLI flags or core `hypa raw` behavior change; this only enforces the Pi adapter's existing documented-in-code restriction.
